### PR TITLE
Update response.js

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -425,8 +425,7 @@ function showPublishSlide(req, res, next) {
                         return;
                     }
                     var body = LZString.decompressFromBase64(data.rows[0].content);
-                    var text = S(body).escapeHTML().s;
-                    render(res, text);
+                    render(res, body);
                 });
             });
         });


### PR DESCRIPTION
用escapeHtml的話對於code highlight的支援性會變低
去掉的話雖然某些語言像是jQuery code可能會看不到
但其他語言就能完整顯示
測試無escapeHtml版本: http://note.xnum.tw/p/VJbpOJr4x#/
如果沒有escapeHtml的話不知道是否會引發其他問題?