### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "jsdom-nogyp": "^0.8.3",
     "lz-string": "1.3.6",
     "markdown-pdf": "^5.2.0",
-    "marked": "^0.3.3",
+    "marked": "^0.3.5",
     "method-override": "^2.3.2",
     "moment": "^2.10.3",
     "mongoose": "^4.0.2",


### PR DESCRIPTION
Bump dependency marked to ^0.3.5

Reference(security issue):

https://nodesecurity.io/advisories/marked_regular-expression-denial-of-service