### PR TITLE
Extend to support GitLab Authentication

### DIFF
--- a/app.js
+++ b/app.js
@@ -292,6 +292,23 @@ if (config.github) {
     //github callback actions
     app.get('/auth/github/callback/:noteId/:action', response.githubActions);
 }
+//gitlab auth
+if (config.gitlab) {
+    app.get('/auth/gitlab',
+        passport.authenticate('gitlab'),
+        function (req, res) {});
+    //gitlab auth callback
+    app.get('/auth/gitlab/callback',
+        passport.authenticate('gitlab', {
+            failureRedirect: config.serverurl
+        }),
+        function (req, res) {
+            res.redirect(config.serverurl);
+        });
+    //gitlab callback actions
+    // TODO: Maybe in the future
+    //app.get('/auth/gitlab/callback/:noteId/:action', response.gitlabActions);
+}
 //dropbox auth
 if (config.dropbox) {
     app.get('/auth/dropbox',

--- a/config.json
+++ b/config.json
@@ -32,6 +32,11 @@
             "clientID": "change this",
             "clientSecret": "change this"
         },
+        "gitlab": {
+            "baseURL": "change this",
+            "clientID": "change this",
+            "clientSecret": "change this"
+        },
         "dropbox": {
             "clientID": "change this",
             "clientSecret": "change this"

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -4,6 +4,7 @@ var passport = require('passport');
 var FacebookStrategy = require('passport-facebook').Strategy;
 var TwitterStrategy = require('passport-twitter').Strategy;
 var GithubStrategy = require('passport-github').Strategy;
+var GitlabStrategy = require('passport-gitlab2').Strategy;
 var DropboxStrategy = require('passport-dropbox-oauth2').Strategy;
 
 //core
@@ -54,6 +55,15 @@ if (config.github) {
         clientID: config.github.clientID,
         clientSecret: config.github.clientSecret,
         callbackURL: config.serverurl + '/auth/github/callback'
+    }, callback));
+}
+//gitlab
+if (config.gitlab) {
+    passport.use(new GitlabStrategy({
+        baseURL: config.gitlab.baseURL,
+        clientID: config.gitlab.clientID,
+        clientSecret: config.gitlab.clientSecret,
+        callbackURL: config.serverurl + '/auth/gitlab/callback'
     }, callback));
 }
 //dropbox

--- a/lib/config.js
+++ b/lib/config.js
@@ -59,6 +59,7 @@ var documentmaxlength = config.documentmaxlength || 100000;
 var facebook = config.facebook || false;
 var twitter = config.twitter || false;
 var github = config.github || false;
+var gitlab = config.gitlab || false;
 var dropbox = config.dropbox || false;
 var imgur = config.imgur || false;
 
@@ -110,6 +111,7 @@ module.exports = {
     facebook: facebook,
     twitter: twitter,
     github: github,
+    gitlab: gitlab,
     dropbox: dropbox,
     imgur: imgur
 };

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -63,6 +63,9 @@ module.exports = function (sequelize, DataTypes) {
                     case "github":
                         photo = 'https://avatars.githubusercontent.com/u/' + profile.id + '?s=48';
                         break;
+                    case "gitlab":
+                        photo = profile.avatarUrl;
+                        break;
                     case "dropbox":
                         //no image api provided, use gravatar
                         photo = 'https://www.gravatar.com/avatar/' + md5(profile.emails[0].value);

--- a/lib/response.js
+++ b/lib/response.js
@@ -94,6 +94,7 @@ function showIndex(req, res, next) {
         facebook: config.facebook,
         twitter: config.twitter,
         github: config.github,
+        gitlab: config.gitlab,
         dropbox: config.dropbox,
     });
     res.write(content);
@@ -124,6 +125,7 @@ function responseHackMD(res, note) {
         facebook: config.facebook,
         twitter: config.twitter,
         github: config.github,
+        gitlab: config.gitlab,
         dropbox: config.dropbox,
     });
     var buf = html;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "passport-dropbox-oauth2": "^1.0.0",
     "passport-facebook": "^2.1.0",
     "passport-github": "^1.1.0",
+    "passport-gitlab2": "^2.2.0",
     "passport-twitter": "^1.0.4",
     "passport.socketio": "^3.6.1",
     "pg": "^4.5.3",

--- a/public/views/signin-modal.ejs
+++ b/public/views/signin-modal.ejs
@@ -28,6 +28,11 @@
                     <i class="fa fa-dropbox"></i> Sign in via Dropbox
                 </a>
                 <% } %>
+                <% if(gitlab) { %>
+                <a href="<%- url %>/auth/gitlab" class="btn btn-lg btn-block btn-social btn-soundcloud">
+                    <i class="fa fa-gitlab"></i> Sign in via GitLab
+                </a>
+                <% } %>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Commit List:
* Add necessary dependency.
* Add baseURL parameter for self-hosted GitLab
* Add necessary require.
* Add block for GitLab auth.
* Fix typo
* Update font-awesome dependency for GitLab icon.
* Use a color closer to GitLab orange.
* More direct TODO

Focus solely on authentication, saving/opening `snippets` not addressed.