### PR TITLE
Fixed typo: anonmyous

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Environment variables (will overwrite other server configs)
 | HMD_PROTOCOL_USESSL | `true` or `false` | set to use ssl protocol for resources path (only applied when domain is set) |
 | HMD_URL_ADDPORT | `true` or `false` | set to add port on callback url (port 80 or 443 won't applied) (only applied when domain is set) |
 | HMD_USECDN | `true` or `false` | set to use CDN resources or not (default is `true`) |
-| HMD_ALLOW_ANONMYOUS | `true` or `false` | set to allow anonmyous usage (default is `true`) |
+| HMD_ALLOW_ANONYMOUS | `true` or `false` | set to allow anonymous usage (default is `true`) |
 | HMD_ALLOW_FREEURL | `true` or `false` | set to allow new note by accessing not exist note url |
 | HMD_FACEBOOK_CLIENTID | no example | Facebook API client id |
 | HMD_FACEBOOK_CLIENTSECRET | no example | Facebook API client secret |
@@ -155,7 +155,7 @@ Server settings `config.json`
 | protocolusessl | `true` or `false` | set to use ssl protocol for resources path (only applied when domain is set) |
 | urladdport | `true` or `false` | set to add port on callback url (port 80 or 443 won't applied) (only applied when domain is set) |
 | usecdn | `true` or `false` | set to use CDN resources or not (default is `true`) |
-| allowanonmyous | `true` or `false` | set to allow anonmyous usage (default is `true`) |
+| allowanonymous | `true` or `false` | set to allow anonymous usage (default is `true`) |
 | allowfreeurl | `true` or `false` | set to allow new note by accessing not exist note url |
 | db | `{ "dialect": "sqlite", "storage": "./db.hackmd.sqlite" }` | set the db configs, [see more here](http://sequelize.readthedocs.org/en/latest/api/sequelize/) |
 | sslkeypath | `./cert/client.key` | ssl key path (only need when you set usessl) |

--- a/lib/config.js
+++ b/lib/config.js
@@ -19,7 +19,7 @@ var urladdport = process.env.HMD_URL_ADDPORT ? (process.env.HMD_URL_ADDPORT === 
 
 var usecdn = process.env.HMD_USECDN ? (process.env.HMD_USECDN === 'true') : ((typeof config.usecdn === 'boolean') ? config.usecdn : true);
 
-var allowanonmyous = process.env.HMD_ALLOW_ANONMYOUS ? (process.env.HMD_ALLOW_ANONMYOUS === 'true') : ((typeof config.allowanonmyous === 'boolean') ? config.allowanonmyous : true);
+var allowanonymous = process.env.HMD_ALLOW_ANONYMOUS ? (process.env.HMD_ALLOW_ANONYMOUS === 'true') : ((typeof config.allowanonymous === 'boolean') ? config.allowanonymous : true);
 
 var allowfreeurl = process.env.HMD_ALLOW_FREEURL ? (process.env.HMD_ALLOW_FREEURL === 'true') : !!config.allowfreeurl;
 
@@ -129,7 +129,7 @@ module.exports = {
     usessl: usessl,
     serverurl: getserverurl(),
     usecdn: usecdn,
-    allowanonmyous: allowanonmyous,
+    allowanonymous: allowanonymous,
     allowfreeurl: allowfreeurl,
     db: db,
     sslkeypath: path.join(cwd, sslkeypath),

--- a/lib/realtime.js
+++ b/lib/realtime.js
@@ -767,7 +767,7 @@ function connection(socket) {
             var note = notes[noteId];
             //Only owner can change permission
             if (note.owner && note.owner == socket.request.user.id) {
-                if (permission == 'freely' && !config.allowanonmyous) return;
+                if (permission == 'freely' && !config.allowanonymous) return;
                 note.permission = permission;
                 models.Note.update({
                     permission: permission

--- a/lib/response.js
+++ b/lib/response.js
@@ -60,7 +60,7 @@ function showIndex(req, res, next) {
     res.render(config.indexpath, {
         url: config.serverurl,
         useCDN: config.usecdn,
-        allowAnonmyous: config.allowanonmyous,
+        allowAnonymous: config.allowanonymous,
         facebook: config.facebook,
         twitter: config.twitter,
         github: config.github,
@@ -93,7 +93,7 @@ function responseHackMD(res, note) {
         url: config.serverurl,
         title: title,
         useCDN: config.usecdn,
-        allowAnonmyous: config.allowanonmyous,
+        allowAnonymous: config.allowanonymous,
         facebook: config.facebook,
         twitter: config.twitter,
         github: config.github,
@@ -108,7 +108,7 @@ function newNote(req, res, next) {
     var owner = null;
     if (req.isAuthenticated()) {
         owner = req.user.id;
-    } else if (!config.allowanonmyous) {
+    } else if (!config.allowanonymous) {
         return response.errorForbidden(res);
     }
     models.Note.create({

--- a/public/views/body.ejs
+++ b/public/views/body.ejs
@@ -15,7 +15,7 @@
                     <a id="permissionLabel" class="ui-permission-label text-uppercase" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                     </a>
                     <ul class="dropdown-menu" aria-labelledby="permissionLabel">
-                        <li class="ui-permission-freely"<% if(!allowAnonmyous) { %> style="display: none;"<% } %>><a><i class="fa fa-leaf fa-fw"></i> Freely - Anyone can edit</a></li>
+                        <li class="ui-permission-freely"<% if(!allowAnonymous) { %> style="display: none;"<% } %>><a><i class="fa fa-leaf fa-fw"></i> Freely - Anyone can edit</a></li>
                         <li class="ui-permission-editable"><a><i class="fa fa-shield fa-fw"></i> Editable - Signed people can edit</a></li>
                         <li class="ui-permission-locked"><a><i class="fa fa-lock fa-fw"></i> Locked - Only owner can edit</a></li>
                         <li class="ui-permission-private"><a><i class="fa fa-hand-stop-o fa-fw"></i> Private - Only owner can view &amp; edit</a></li>

--- a/public/views/index.ejs
+++ b/public/views/index.ejs
@@ -63,10 +63,10 @@
                             <a type="button" class="btn btn-lg btn-success ui-signin" data-toggle="modal" data-target=".signin-modal" style="min-width: 170px;"><%= __('Sign In') %></a>
                         </span>
                         <% }%>
-                        <% if((facebook || twitter || github || gitlab || dropbox || google || email) && allowAnonmyous) { %>
+                        <% if((facebook || twitter || github || gitlab || dropbox || google || email) && allowAnonymous) { %>
                         <span class="ui-or"><%= __('or') %></span>
                         <% }%>
-                        <% if(allowAnonmyous) { %>
+                        <% if(allowAnonymous) { %>
                         <span class="ui-signin">
                             <a href="<%- url %>/new" class="btn btn-lg btn-default" style="min-width: 170px;"><%= __('New guest note') %></a>
                             <br>


### PR DESCRIPTION
Commit 5c7eb483198d0d92dc88c7a7c25cca5c23eb5cf2 added the configuration value `allowanonmyous` and the environment variable `HMD_ALLOW_ANONMYOUS`. The word *anonymous* is misspelled consistently throughout the code, which is fixed by this pull request.

Having these names misspelled can lead to unexpected behavior for users who do not copy/paste the variable names, so supporting the correctly spelled names should be desirable.

In its current stage, the pull request does not recognize the misspelled names introduced in 5c7eb483198d0d92dc88c7a7c25cca5c23eb5cf2. I think this is a very minor breaking change, but if desired, I could add support for the misspelled names as a fallback.