### PR TITLE
Fix URL concatenation when uploading images to local filesystem

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,7 @@ var compression = require('compression')
 var session = require('express-session');
 var SequelizeStore = require('connect-session-sequelize')(session.Store);
 var fs = require('fs');
+var url = require('url');
 var path = require('path');
 var imgur = require('imgur');
 var formidable = require('formidable');
@@ -487,7 +488,7 @@ app.post('/uploadimage', function (req, res) {
                 switch (config.imageUploadType) {
                 case 'filesystem':
                     res.send({
-                        link: path.join(config.serverurl, files.image.path.match(/^public(.+$)/)[1])
+                        link: url.resolve(config.serverurl, files.image.path.match(/^public(.+$)/)[1])
                     });
 
                     break;


### PR DESCRIPTION
Fixed an issue where URLs are not handled correctly when uploading images to local filesystem.

For example, if the URL of your hackmd server is https://example.com/, the markdown inserted at the time of image drop will be in a state where the slash is insufficient as follows.

```
![](https:/example.com/uploads/upload_912f83d804cb0219ae628d1062d4f8f0.jpg)
```

This is due to using the path.join of Node.js, and solving it by using the url.resolve instead.

```
var serverUrl = 'https://example.com/'
var imagePath = 'uploads/upload_912f83d804cb0219ae628d1062d4f8f0.jpg'
path.join(serverUrl, imagePath)
// Returns: 'https:/example.com/uploads/upload_912f83d804cb0219ae628d1062d4f8f0.jpg'
url.resolve(serverUrl, imagePath)
// Returns: 'https://example.com/uploads/upload_912f83d804cb0219ae628d1062d4f8f0.jpg'
```
