### PR TITLE
Add fail fast option

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # run command at repo root
 CURRENT_PATH=$PWD
 if [ -d .git ]; then


### PR DESCRIPTION
Fail the script if a command inside it fails to prevent a install with exitcode 0 even when commands in it are failing.