### PR TITLE
Add additional comment about Prerequisite to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Prerequisite
 - Node.js 4.x or up (test up to 6.7.0)
 - Database (PostgreSQL, MySQL, MariaDB, SQLite, MSSQL) use charset `utf8`
 - npm
+- gcc/make
+	- `yum groupinstall 'Development Tools'` for RHEL, `sudo apt-get install build-essential` for Debian
 
 Get started
 ---

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Prerequisite
 - Database (PostgreSQL, MySQL, MariaDB, SQLite, MSSQL) use charset `utf8`
 - npm
 - gcc/make
-	- `yum groupinstall 'Development Tools'` for RHEL, `sudo apt-get install build-essential` for Debian
+	- `sudo yum groupinstall 'Development Tools'` for RHEL, `sudo apt-get install build-essential` for Debian
 
 Get started
 ---

--- a/README.md
+++ b/README.md
@@ -50,9 +50,7 @@ Prerequisite
 
 - Node.js 4.x or up (test up to 6.7.0)
 - Database (PostgreSQL, MySQL, MariaDB, SQLite, MSSQL) use charset `utf8`
-- npm
-- gcc/make
-	- `sudo yum groupinstall 'Development Tools'` for RHEL, `sudo apt-get install build-essential` for Debian
+- npm (and its dependencies, especially [uWebSockets](https://github.com/uWebSockets/uWebSockets#nodejs-developers), [node-gyp](https://github.com/nodejs/node-gyp#installation))
 
 Get started
 ---


### PR DESCRIPTION
`make` and `gcc` are required in [node-gyp](https://www.npmjs.com/package/node-gyp).

Without these packages, `bin/setup` ,which is instructed in Get started will fail.