### PR TITLE
Add default permission config

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Environment variables (will overwrite other server configs)
 | HMD_USECDN | `true` or `false` | set to use CDN resources or not (default is `true`) |
 | HMD_ALLOW_ANONYMOUS | `true` or `false` | set to allow anonymous usage (default is `true`) |
 | HMD_ALLOW_FREEURL | `true` or `false` | set to allow new note by accessing not exist note url |
-| HMD_DEFAULT_PERMISSION | `freely`, `editable`, `limited`, `locked` or `private` | when creates new note, uses this permission (only applied when logged in) |
+| HMD_DEFAULT_PERMISSION | `freely`, `editable`, `limited`, `locked` or `private` | set notes default permission (only applied on signed users) |
 | HMD_DB_URL | `mysql://localhost:3306/database` | set the db url |
 | HMD_FACEBOOK_CLIENTID | no example | Facebook API client id |
 | HMD_FACEBOOK_CLIENTSECRET | no example | Facebook API client secret |
@@ -165,7 +165,7 @@ Application settings `config.json`
 | usecdn | `true` or `false` | set to use CDN resources or not (default is `true`) |
 | allowanonymous | `true` or `false` | set to allow anonymous usage (default is `true`) |
 | allowfreeurl | `true` or `false` | set to allow new note by accessing not exist note url |
-| defaultpermission | `freely`, `editable`, `limited`, `locked` or `private` | when creates new note, uses this permission (only applied when logged in) |
+| defaultpermission | `freely`, `editable`, `limited`, `locked` or `private` | set notes default permission (only applied on signed users) |
 | dburl | `mysql://localhost:3306/database` | set the db url, if set this variable then below db config won't be applied |
 | db | `{ "dialect": "sqlite", "storage": "./db.hackmd.sqlite" }` | set the db configs, [see more here](http://sequelize.readthedocs.org/en/latest/api/sequelize/) |
 | sslkeypath | `./cert/client.key` | ssl key path (only need when you set usessl) |

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Environment variables (will overwrite other server configs)
 | HMD_USECDN | `true` or `false` | set to use CDN resources or not (default is `true`) |
 | HMD_ALLOW_ANONYMOUS | `true` or `false` | set to allow anonymous usage (default is `true`) |
 | HMD_ALLOW_FREEURL | `true` or `false` | set to allow new note by accessing not exist note url |
+| HMD_DEFAULT_PERMISSION | `freely`, `editable`, `limited`, `locked` or `private` | when creates new note, uses this permission (only applied when logged in) |
 | HMD_DB_URL | `mysql://localhost:3306/database` | set the db url |
 | HMD_FACEBOOK_CLIENTID | no example | Facebook API client id |
 | HMD_FACEBOOK_CLIENTSECRET | no example | Facebook API client secret |
@@ -164,6 +165,7 @@ Application settings `config.json`
 | usecdn | `true` or `false` | set to use CDN resources or not (default is `true`) |
 | allowanonymous | `true` or `false` | set to allow anonymous usage (default is `true`) |
 | allowfreeurl | `true` or `false` | set to allow new note by accessing not exist note url |
+| defaultpermission | `freely`, `editable`, `limited`, `locked` or `private` | when creates new note, uses this permission (only applied when logged in) |
 | dburl | `mysql://localhost:3306/database` | set the db url, if set this variable then below db config won't be applied |
 | db | `{ "dialect": "sqlite", "storage": "./db.hackmd.sqlite" }` | set the db configs, [see more here](http://sequelize.readthedocs.org/en/latest/api/sequelize/) |
 | sslkeypath | `./cert/client.key` | ssl key path (only need when you set usessl) |

--- a/lib/config.js
+++ b/lib/config.js
@@ -24,6 +24,9 @@ var allowanonymous = process.env.HMD_ALLOW_ANONYMOUS ? (process.env.HMD_ALLOW_AN
 
 var allowfreeurl = process.env.HMD_ALLOW_FREEURL ? (process.env.HMD_ALLOW_FREEURL === 'true') : !!config.allowfreeurl;
 
+var defaultpermission = process.env.HMD_DEFAULT_PERMISSION || config.defaultpermission || 'editable';
+defaultpermission = (!allowanonymous && defaultpermission == 'freely') ? 'editable' : defaultpermission;
+
 // db
 var dburl = config.dburl || process.env.HMD_DB_URL || process.env.DATABASE_URL;
 var db = config.db || {};
@@ -173,6 +176,7 @@ module.exports = {
     usecdn: usecdn,
     allowanonymous: allowanonymous,
     allowfreeurl: allowfreeurl,
+    defaultpermission: defaultpermission,
     dburl: dburl,
     db: db,
     sslkeypath: path.join(cwd, sslkeypath),

--- a/lib/config.js
+++ b/lib/config.js
@@ -24,8 +24,13 @@ var allowanonymous = process.env.HMD_ALLOW_ANONYMOUS ? (process.env.HMD_ALLOW_AN
 
 var allowfreeurl = process.env.HMD_ALLOW_FREEURL ? (process.env.HMD_ALLOW_FREEURL === 'true') : !!config.allowfreeurl;
 
-var defaultpermission = process.env.HMD_DEFAULT_PERMISSION || config.defaultpermission || 'editable';
-defaultpermission = (!allowanonymous && defaultpermission == 'freely') ? 'editable' : defaultpermission;
+var permissions = ['editable', 'limited', 'locked', 'protected', 'private'];
+if (allowanonymous) {
+    permissions.unshift('freely');
+}
+
+var defaultpermission = process.env.HMD_DEFAULT_PERMISSION || config.defaultpermission;
+defaultpermission = permissions.indexOf(defaultpermission) != -1 ? defaultpermission : 'editable';
 
 // db
 var dburl = config.dburl || process.env.HMD_DB_URL || process.env.DATABASE_URL;

--- a/lib/models/note.js
+++ b/lib/models/note.js
@@ -513,10 +513,10 @@ module.exports = function (sequelize, DataTypes) {
                         }
                     }
                 }
-                // if no permission specified and have owner then give editable permission, else default permission is freely
+                // if no permission specified and have owner then give default permission in config, else default permission is freely
                 if (!note.permission) {
                     if (note.ownerId) {
-                        note.permission = "editable";
+                        note.permission = config.defaultpermission;
                     } else {
                         note.permission = "freely";
                     }


### PR DESCRIPTION
Use `defaultpermission`(config.json) or `HMD_DEFAULT_PERMISSION`(environment value) to set default permission of newly created note.