### PR TITLE
Fix image path problem when using filesystem backend

### DIFF
--- a/app.js
+++ b/app.js
@@ -502,7 +502,7 @@ app.post('/uploadimage', function (req, res) {
                 switch (config.imageUploadType) {
                 case 'filesystem':
                     res.send({
-                        link: url.resolve(config.serverurl, files.image.path.match(/^public(.+$)/)[1])
+                        link: url.resolve(config.serverurl + '/', files.image.path.match(/^public\/(.+$)/)[1])
                     });
 
                     break;


### PR DESCRIPTION
When using `filesystem` backend in `imageUploadType` and `config.serverurl` is set, path to uploaded image is wrong.