### PR TITLE
Move to Ubuntu Trusty on Travis CI and remove apt add-on

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,9 @@
 language: node_js
+dist: trusty
 node_js:
   - 6
   - 7
   - lts/boron
 env:
   - CXX=g++-4.8
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
 cache: yarn


### PR DESCRIPTION
Two reasons here:

1) Ubuntu Precise is reaching EOL, though Travis CI may take care of it.
we still can move to Trusty earlier as I didn't see any dependency of
Precise here.

2) g++4.8 is built-in in Travis CI's Ubuntu Trusty environment, which
means we don't need to spend time on adding ppa repository, apt update
and apt install, could save time on the CI.