### PR TITLE
Fix heroku deployment

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,9 +10,6 @@
     "repository": "https://github.com/hackmdio/hackmd",
     "logo": "https://github.com/hackmdio/hackmd/raw/master/public/hackmd-icon-1024.png",
     "success_url": "/",
-    "scripts": {
-        "postdeploy": "./node_modules/.bin/sequelize db:migrate"
-    },
     "env": {
         "BUILD_ASSETS": {
             "description": "Our build script variable",

--- a/bin/heroku
+++ b/bin/heroku
@@ -3,8 +3,6 @@
 set -e
 
 if [ "$BUILD_ASSETS" = true ]; then
-  BUILD_ASSETS=false npm install
-
   # setup config files
   cat << EOF > .sequelizerc
 var path = require('path');


### PR DESCRIPTION
### Changes

- Remove `postdeploy` section in heroku `app.json`.  For a clean application, there is no need to run sequelize migration.
- Remove `npm install` from heroku script. Heroku detects `yarn.lock` automatically and install package for us.