### PR TITLE
Image Upload to S3 - ContentType not set

### DIFF
--- a/app.js
+++ b/app.js
@@ -548,6 +548,9 @@ app.post('/uploadimage', function (req, res) {
                 Body: buffer
               }
 
+              var mimeType = getImageMimeType(files.image.path)
+              if (mimeType) { params.ContentType = mimeType }
+
               s3.putObject(params, function (err, data) {
                 if (err) {
                   logger.error(err)

--- a/app.js
+++ b/app.js
@@ -22,6 +22,9 @@ var i18n = require('i18n')
 var flash = require('connect-flash')
 var validator = require('validator')
 
+// utils
+var getImageMimeType = require('./lib/utils.js').getImageMimeType
+
 // core
 var config = require('./lib/config.js')
 var logger = require('./lib/logger.js')

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,17 +8,17 @@ exports.getImageMimeType = function getImageMimeType (imagePath) {
   var fileExtension = /[^.]+$/.exec(imagePath)
 
   switch (fileExtension[0]) {
-    case "bmp":
-      return "image/bmp"
-    case "gif":
-      return "image/gif"
-    case "jpg":
-    case "jpeg":
-      return "image/jpeg"
-    case "png":
-      return "image/png"
-    case "tiff":
-      return "image/tiff"
+    case 'bmp':
+      return 'image/bmp'
+    case 'gif':
+      return 'image/gif'
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg'
+    case 'png':
+      return 'image/png'
+    case 'tiff':
+      return 'image/tiff'
     default:
       return undefined
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,3 +3,23 @@
 exports.isSQLite = function isSQLite (sequelize) {
   return sequelize.options.dialect === 'sqlite'
 }
+
+exports.getImageMimeType = function getImageMimeType (imagePath) {
+  var fileExtension = /[^.]+$/.exec(imagePath)
+
+  switch (fileExtension[0]) {
+    case "bmp":
+      return "image/bmp"
+    case "gif":
+      return "image/gif"
+    case "jpg":
+    case "jpeg":
+      return "image/jpeg"
+    case "png":
+      return "image/png"
+    case "tiff":
+      return "image/tiff"
+    default:
+      return undefined
+  }
+}


### PR DESCRIPTION
As discussed in the issue https://github.com/hackmdio/hackmd/issues/435, when an image is uploaded to S3, no Content-Type is set. When you try to open the image in a new tab, it starts to download the image.

With this PR, I have added a simple functionality that adds the Content-Type to the image, so the images are processed as images instead of stream objects.

It also helps to create markdowns in Hackmd and use them into Github repos showing the images correctly.