### PR TITLE
Fix error: uncaughtException: listen EACCES 0.0.0.0:80 on heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -32,11 +32,6 @@
             "description": "sub url path, like `www.example.com/<URL_PATH>`",
             "required": false
         },
-        "HMD_PORT": {
-            "description": "web app port",
-            "required": false,
-            "value": "80"
-        },
         "HMD_ALLOW_ORIGIN": {
             "description": "domain name whitelist (use comma to separate)",
             "required": false,


### PR DESCRIPTION
## TL;DR

![screen shot 2017-05-14 at 7 10 50 pm](https://cloud.githubusercontent.com/assets/4230968/26033186/3f51890e-38d9-11e7-8e09-44c398609c77.png)

**For existing heroku users, remove `HMD_PORT` from your heroku app setting.**

### Changes

Hackmd choose `HMD_PORT` over `PORT` value after #421. This caused heroku application won't start correctly. So just removed it.

### Error messages in heroku log

> error: uncaughtException: listen EACCES 0.0.0.0:80