### PR TITLE
stop the slide number being cut off

### DIFF
--- a/public/css/slide.css
+++ b/public/css/slide.css
@@ -319,6 +319,10 @@ html, body {
     position: absolute;
 }
 
+.reveal .slide-number {
+    right: 24px;
+}
+
 .print-pdf .container {
     position: relative;
     overflow-y: hidden;


### PR DESCRIPTION
i noticed the slide number on reveal was being cut off this is due to the positioning assuming is position fixed, with absolute it needs to be moved in a bit