### PR TITLE
Use non-zero exit codes when build fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "npm run-script standard",
     "standard": "node ./node_modules/standard/bin/cmd.js",
     "dev": "webpack --config webpack.config.js --progress --colors --watch",
-    "build": "webpack --config webpack.production.js --progress --colors",
+    "build": "webpack --config webpack.production.js --progress --colors --bail",
     "postinstall": "bin/heroku",
     "start": "node app.js"
   },


### PR DESCRIPTION
Use `--bail` option to exit with a non-zero code when `webpack` fails instead ending successfully.

It also provides more useful debug output on fail.