### PR TITLE
fix s3 us-east-1 region endpoint

### DIFF
--- a/lib/web/imageRouter.js
+++ b/lib/web/imageRouter.js
@@ -64,8 +64,11 @@ imageRouter.post('/uploadimage', function (req, res) {
                   res.status(500).end('upload image error')
                   return
                 }
+
+                var s3Endpoint = 's3.amazonaws.com'
+                if (config.s3.region && config.s3.region !== 'us-east-1') { s3Endpoint = `s3-${config.s3.region}.amazonaws.com` }
                 res.send({
-                  link: `https://s3-${config.s3.region}.amazonaws.com/${config.s3bucket}/${params.Key}`
+                  link: `https://${s3Endpoint}/${config.s3bucket}/${params.Key}`
                 })
               })
             })


### PR DESCRIPTION
Fix Amazon S3 endpoint URL in us-east-1.

http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region

* us-east-1(not contain `-${region}`):
```
s3.amazonaws.com
```

* other regions:
```
s3-${region}.amazonaws.com
```