### PR TITLE
Add support for minio

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -48,6 +48,13 @@ module.exports = {
     secretAccessKey: undefined,
     region: undefined
   },
+  minio: {
+    accessKey: undefined,
+    secretKey: undefined,
+    endPoint: undefined,
+    secure: true,
+    port: 9000
+  },
   s3bucket: undefined,
   // authentication
   facebook: {

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -24,6 +24,13 @@ module.exports = {
     secretAccessKey: process.env.HMD_S3_SECRET_ACCESS_KEY,
     region: process.env.HMD_S3_REGION
   },
+  minio: {
+    accessKey: process.env.HMD_MINIO_ACCESS_KEY,
+    secretKey: process.env.HMD_MINIO_SECRET_KEY,
+    endPoint: process.env.HMD_MINIO_ENDPOINT,
+    secure: toBooleanConfig(process.env.HMD_MINIO_SECURE),
+    port: parseInt(process.env.HMD_MINIO_PORT)
+  },
   s3bucket: process.env.HMD_S3_BUCKET,
   facebook: {
     clientID: process.env.HMD_FACEBOOK_CLIENTID,

--- a/lib/web/imageRouter.js
+++ b/lib/web/imageRouter.js
@@ -73,6 +73,40 @@ imageRouter.post('/uploadimage', function (req, res) {
               })
             })
             break
+
+          case 'minio':
+            var utils = require('../utils')
+            var Minio = require('minio')
+            var minioClient = new Minio.Client({
+              endPoint: config.minio.endPoint,
+              port: config.minio.port,
+              secure: config.minio.secure,
+              accessKey: config.minio.accessKey,
+              secretKey: config.minio.secretKey
+            })
+            fs.readFile(files.image.path, function (err, buffer) {
+              if (err) {
+                logger.error(err)
+                res.status(500).end('upload image error')
+                return
+              }
+
+              var key = path.join('uploads', path.basename(files.image.path))
+              var protocol = config.minio.secure ? 'https' : 'http'
+
+              minioClient.putObject(config.s3bucket, key, buffer, buffer.size, utils.getImageMimeType(files.image.path), function (err, data) {
+                if (err) {
+                  logger.error(err)
+                  res.status(500).end('upload image error')
+                  return
+                }
+                res.send({
+                  link: `${protocol}://${config.minio.endPoint}:${config.minio.port}/${config.s3bucket}/${key}`
+                })
+              })
+            })
+            break
+
           case 'imgur':
           default:
             imgur.setClientId(config.imgur.clientID)

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "mermaid": "~7.0.0",
     "meta-marked": "^0.4.2",
     "method-override": "^2.3.7",
+    "minio": "^3.1.3",
     "moment": "^2.17.1",
     "morgan": "^1.7.0",
     "mysql": "^2.12.0",


### PR DESCRIPTION
I know of the existence of #345 but it hasn't been updated in a while and there have been some changes on master that make that pull request useless.

I tried using our minio instance as if it were and Amazon S3 endpoint ( adding a slight change to support a different endpoint than the defaults from Amazon) but the aws-sdk refused to work ( for some reason it still contacts Amazon to verify the credentials).

Thus, I ended up opting for adding full support for minio using https://github.com/minio/minio-js

I also noticed that there is an s3bucket config option which somehow I believe it belongs to the s3 section but I didn't dare to change that.