### PR TITLE
Set default permission on creation of freeurl Note

### DIFF
--- a/lib/models/note.js
+++ b/lib/models/note.js
@@ -43,7 +43,10 @@ module.exports = function (sequelize, DataTypes) {
     },
     permission: {
       type: DataTypes.ENUM,
-      values: permissionTypes
+      values: permissionTypes,
+      get: function () {
+        return this.getDataValue('permission') || config.defaultpermission
+      }
     },
     viewcount: {
       type: DataTypes.INTEGER,


### PR DESCRIPTION
If use freeurl style to create Note, the note's permission will be `null`.
This patch try to assign default permission to freeurl Note.