### PR TITLE
Fix #420, avoid undefined content on newNote

### DIFF
--- a/lib/models/note.js
+++ b/lib/models/note.js
@@ -61,6 +61,7 @@ module.exports = function (sequelize, DataTypes) {
     },
     content: {
       type: DataTypes.TEXT,
+      defaultValue: '',
       get: function () {
         return sequelize.processData(this.getDataValue('content'), '')
       },


### PR DESCRIPTION
Fix #420 by avoid to return undefined content. 
However if other places check `undefined content` in its logic flow, this patch will have side affect.