### PR TITLE
Remove URL when export to PDF

### DIFF
--- a/public/css/extra.css
+++ b/public/css/extra.css
@@ -362,6 +362,6 @@ small .dropdown a:focus, small .dropdown a:hover {
         page-break-inside: avoid !important;
     }
     a[href]:after {
-        font-size: 12px !important;
+        content: none !important;
     }
 }


### PR DESCRIPTION
Mentioned in #535, I would like to remove the URLs shown next to links when export PDF using browser built-in print. The link in PDF is still available, in my personal opinion, the URL is unnecessary.