### PR TITLE
Specify S3 bucket like advertised in documentation

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -46,9 +46,9 @@ module.exports = {
   s3: {
     accessKeyId: undefined,
     secretAccessKey: undefined,
-    region: undefined
+    region: undefined,
+    bucket: undefined
   },
-  s3bucket: undefined,
   // authentication
   facebook: {
     clientID: undefined,

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -22,9 +22,9 @@ module.exports = {
   s3: {
     accessKeyId: process.env.HMD_S3_ACCESS_KEY_ID,
     secretAccessKey: process.env.HMD_S3_SECRET_ACCESS_KEY,
-    region: process.env.HMD_S3_REGION
+    region: process.env.HMD_S3_REGION,
+    bucket: process.env.HMD_S3_BUCKET
   },
-  s3bucket: process.env.HMD_S3_BUCKET,
   facebook: {
     clientID: process.env.HMD_FACEBOOK_CLIENTID,
     clientSecret: process.env.HMD_FACEBOOK_CLIENTSECRET

--- a/lib/web/imageRouter.js
+++ b/lib/web/imageRouter.js
@@ -50,7 +50,7 @@ imageRouter.post('/uploadimage', function (req, res) {
                 return
               }
               var params = {
-                Bucket: config.s3bucket,
+                Bucket: config.s3.bucket,
                 Key: path.join('uploads', path.basename(files.image.path)),
                 Body: buffer
               }
@@ -68,7 +68,7 @@ imageRouter.post('/uploadimage', function (req, res) {
                 var s3Endpoint = 's3.amazonaws.com'
                 if (config.s3.region && config.s3.region !== 'us-east-1') { s3Endpoint = `s3-${config.s3.region}.amazonaws.com` }
                 res.send({
-                  link: `https://${s3Endpoint}/${config.s3bucket}/${params.Key}`
+                  link: `https://${s3Endpoint}/${config.s3.bucket}/${params.Key}`
                 })
               })
             })


### PR DESCRIPTION
Documentation added in aaf034b on Nov 17th 2016 says the S3 bucket can be specified with `s3.bucket`, but commit c8bcc4c (#285) on Dec 18th 2016 used `s3bucket`. Following the documentation now leads to this exception:

    2017-09-23T09:42:38.079Z - error:  MissingRequiredParameter: Missing required key 'Bucket' in params
        at ParamValidator.fail (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/param_validator.js:50:37)
        at ParamValidator.validateStructure (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/param_validator.js:61:14)
        at ParamValidator.validateMember (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/param_validator.js:88:21)
        at ParamValidator.validate (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/param_validator.js:34:10)
        at Request.VALIDATE_PARAMETERS (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/event_listeners.js:125:42)
        at Request.callListeners (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
        at callNextListener (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/sequential_executor.js:95:12)
        at /srv/hackmd/hackmd/node_modules/aws-sdk/lib/event_listeners.js:85:9
        at finish (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/config.js:315:7)
        at /srv/hackmd/hackmd/node_modules/aws-sdk/lib/config.js:333:9
        at Credentials.get (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/credentials.js:126:7)
        at getAsyncCredentials (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/config.js:327:24)
        at Config.getCredentials (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/config.js:347:9)
        at Request.VALIDATE_CREDENTIALS (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/event_listeners.js:80:26)
        at Request.callListeners (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/sequential_executor.js:101:18)
        at Request.emit (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/sequential_executor.js:77:10)