### PR TITLE
Correct documentation of S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,8 @@ Application settings `config.json`
 | email | `true` or `false` | set to allow email signin |
 | allowemailregister  | `true` or `false` | set to allow email register (only applied when email is set, default is `true`) |
 | imageUploadType | `imgur`(default), `s3` or `filesystem` | Where to upload image
-| s3 | `{ "accessKeyId": "YOUR_S3_ACCESS_KEY_ID", "secretAccessKey": "YOUR_S3_ACCESS_KEY", "region": "YOUR_S3_REGION", "bucket": "YOUR_S3_BUCKET_NAME" }` | When `imageUploadType` be setted to `s3`, you would also need to setup this key, check our [S3 Image Upload Guide](docs/guides/s3-image-upload.md) |
+| s3 | `{ "accessKeyId": "YOUR_S3_ACCESS_KEY_ID", "secretAccessKey": "YOUR_S3_ACCESS_KEY", "region": "YOUR_S3_REGION" }` | When `imageUploadType` be setted to `s3`, you would also need to setup this key, check our [S3 Image Upload Guide](docs/guides/s3-image-upload.md) |
+| s3bucket | `YOUR_S3_BUCKET_NAME` | bucket name when `imageUploadType` is set to `s3` |
 
 Third-party integration api key settings
 ---

--- a/docs/guides/s3-image-upload.md
+++ b/docs/guides/s3-image-upload.md
@@ -67,9 +67,9 @@
             "s3": {
                 "accessKeyId": "YOUR_S3_ACCESS_KEY_ID",
                 "secretAccessKey": "YOUR_S3_ACCESS_KEY",
-                "region": "YOUR_S3_REGION", // example: ap-northeast-1
-                "bucket": "YOUR_S3_BUCKET_NAME"
-            }
+                "region": "YOUR_S3_REGION" // example: ap-northeast-1
+            },
+            "s3bucket": "YOUR_S3_BUCKET_NAME"
         }
     }
     ```


### PR DESCRIPTION
Documentation added in aaf034b on Nov 17th 2016 says the S3 bucket can be specified with `s3.bucket`, but commit c8bcc4c (#285) on Dec 18th 2016 used `s3bucket`. Instead of fixing the code (#552) to match the documentation this commit changes just the documentation so that existing configurations are not broken. Also, the `s3` object is passed as is to `AWS.S3()`, which does not know the option `bucket` (but silently ignores it in my test).

http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property

Following the old documentation leads to this exception:

    2017-09-23T09:42:38.079Z - error:  MissingRequiredParameter: Missing required key 'Bucket' in params
        at ParamValidator.fail (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/param_validator.js:50:37)
        at ParamValidator.validateStructure (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/param_validator.js:61:14)
        at ParamValidator.validateMember (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/param_validator.js:88:21)
        at ParamValidator.validate (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/param_validator.js:34:10)
        at Request.VALIDATE_PARAMETERS (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/event_listeners.js:125:42)
        at Request.callListeners (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
        at callNextListener (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/sequential_executor.js:95:12)
        at /srv/hackmd/hackmd/node_modules/aws-sdk/lib/event_listeners.js:85:9
        at finish (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/config.js:315:7)
        at /srv/hackmd/hackmd/node_modules/aws-sdk/lib/config.js:333:9
        at Credentials.get (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/credentials.js:126:7)
        at getAsyncCredentials (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/config.js:327:24)
        at Config.getCredentials (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/config.js:347:9)
        at Request.VALIDATE_CREDENTIALS (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/event_listeners.js:80:26)
        at Request.callListeners (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/sequential_executor.js:101:18)
        at Request.emit (/srv/hackmd/hackmd/node_modules/aws-sdk/lib/sequential_executor.js:77:10)