### PR TITLE
Fix LDAP problem about missing uidNumber

### DIFF
--- a/lib/web/auth/ldap/index.js
+++ b/lib/web/auth/ldap/index.js
@@ -23,9 +23,10 @@ passport.use(new LDAPStrategy({
     tlsOptions: config.ldap.tlsOptions || null
   }
 }, function (user, done) {
+  var uuid = user.uidNumber || user.uid || user.sAMAccountName
   var profile = {
-    id: 'LDAP-' + user.uidNumber,
-    username: user.uid,
+    id: 'LDAP-' + uuid,
+    username: uuid,
     displayName: user.displayName,
     emails: user.mail ? [user.mail] : [],
     avatarUrl: null,


### PR DESCRIPTION
Try to fix #432

After checking multiple RFCs and references `uid` and `sAMAccountName` seem to be the most commonly used fields.

`uidNumber` is a POSIX reference for the uid that is used when people log in to a Unix host. This should not be used for HackMD.

I don't think that it's a perfect solution. My first try was to add a settings field for it, but it seems to overcomplicate things and is unnecessary long.

I'll test this later. Hopefully during this weekend.