### PR TITLE
Updates default max_line_len in uglifyjs

### DIFF
--- a/webpack.production.js
+++ b/webpack.production.js
@@ -17,6 +17,9 @@ module.exports = [Object.assign({}, baseConfig, {
         compress: {
           warnings: false
         },
+        output: {
+          max_line_len: 1000000
+        },
         mangle: false,
         sourceMap: false
       }


### PR DESCRIPTION
Changes:
- Bumps the max line length from default value of 30000

Fixes: #388 