### PR TITLE
converting all content fields to MEDIUMTEXT (affects MySQL only)

### DIFF
--- a/lib/migrations/20171009121200-longtext-for-mysql.js
+++ b/lib/migrations/20171009121200-longtext-for-mysql.js
@@ -1,0 +1,16 @@
+'use strict'
+module.exports = {
+  up: function (queryInterface, Sequelize) {
+    queryInterface.changeColumn('Notes', 'content', {type: Sequelize.TEXT('long')})
+    queryInterface.changeColumn('Revisions', 'patch', {type: Sequelize.TEXT('long')})
+    queryInterface.changeColumn('Revisions', 'content', {type: Sequelize.TEXT('long')})
+    queryInterface.changeColumn('Revisions', 'latContent', {type: Sequelize.TEXT('long')})
+  },
+
+  down: function (queryInterface, Sequelize) {
+    queryInterface.changeColumn('Notes', 'content', {type: Sequelize.TEXT})
+    queryInterface.changeColumn('Revisions', 'patch', {type: Sequelize.TEXT})
+    queryInterface.changeColumn('Revisions', 'content', {type: Sequelize.TEXT})
+    queryInterface.changeColumn('Revisions', 'latContent', {type: Sequelize.TEXT})
+  }
+}

--- a/lib/models/note.js
+++ b/lib/models/note.js
@@ -60,7 +60,7 @@ module.exports = function (sequelize, DataTypes) {
       }
     },
     content: {
-      type: DataTypes.TEXT,
+      type: DataTypes.TEXT('long'),
       get: function () {
         return sequelize.processData(this.getDataValue('content'), '')
       },

--- a/lib/models/revision.js
+++ b/lib/models/revision.js
@@ -58,7 +58,7 @@ module.exports = function (sequelize, DataTypes) {
       defaultValue: Sequelize.UUIDV4
     },
     patch: {
-      type: DataTypes.TEXT,
+      type: DataTypes.TEXT('long'),
       get: function () {
         return sequelize.processData(this.getDataValue('patch'), '')
       },
@@ -67,7 +67,7 @@ module.exports = function (sequelize, DataTypes) {
       }
     },
     lastContent: {
-      type: DataTypes.TEXT,
+      type: DataTypes.TEXT('long'),
       get: function () {
         return sequelize.processData(this.getDataValue('lastContent'), '')
       },
@@ -76,7 +76,7 @@ module.exports = function (sequelize, DataTypes) {
       }
     },
     content: {
-      type: DataTypes.TEXT,
+      type: DataTypes.TEXT('long'),
       get: function () {
         return sequelize.processData(this.getDataValue('content'), '')
       },


### PR DESCRIPTION
This fixes #521 by making the `TEXT` column larger for MySQL / MariaDB. In PostgreSQL, `TEXT` is already very large, but on MySQL this is just ~64KiB long.

Includes a migration to enable this. This should not change anything on PostgreSQL, as Sequelize maps the field to `TEXT` on that platorm anyway.

Can somebody please confirm that this does not break (or in fact change) PostgreSQL? You'll need to run 

`node_modules/.bin/sequelize db:migrate` (perhaps with your environment)