### PR TITLE
Link constants.js to ./tmp for heroku deployments

### DIFF
--- a/bin/heroku
+++ b/bin/heroku
@@ -28,4 +28,8 @@ EOF
 
   # build app
   npm run build
+
+  # Link "constant.js" to the writable temp directory for Heroku deployments
+  ln -s ./tmp/constant.js ./public/build/constant.js
 fi
+

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "webpack --config webpack.config.js --progress --colors --watch",
     "build": "webpack --config webpack.production.js --progress --colors --bail",
     "postinstall": "bin/heroku",
-    "start": "node app.js"
+    "start": "ls -la ./public/build/ && node app.js"
   },
   "dependencies": {
     "Idle.Js": "git+https://github.com/shawnmclean/Idle.js",


### PR DESCRIPTION
Fixes #500 

It would be nice when someone can verify that this fixes the Heroku deployments.