### PR TITLE
Remove duplicated nodejs version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: trusty
 node_js:
   - 6
   - 7
-  - lts/boron
 env:
   - CXX=g++-4.8
 cache: yarn


### PR DESCRIPTION
lts/boron is v6