### PR TITLE
Fix missing boolean setting for HMD_URL_ADDPORT

### DIFF
--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -6,7 +6,7 @@ module.exports = {
   domain: process.env.HMD_DOMAIN,
   urlpath: process.env.HMD_URL_PATH,
   port: process.env.HMD_PORT,
-  urladdport: process.env.HMD_URL_ADDPORT,
+  urladdport: toBooleanConfig(process.env.HMD_URL_ADDPORT),
   usessl: toBooleanConfig(process.env.HMD_USESSL),
   protocolusessl: toBooleanConfig(process.env.HMD_PROTOCOL_USESSL),
   alloworigin: process.env.HMD_ALLOW_ORIGIN ? process.env.HMD_ALLOW_ORIGIN.split(',') : undefined,


### PR DESCRIPTION
`HMD_URL_ADDPORT` wasn't parsed correctly and caused broken pages by adding the port number no matter if it's `true` or `false`.