### PR TITLE
Make HSTS Behaviour Configurable (Fixes #584)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Application settings `config.json`
 | port | `80` | web app port |
 | alloworigin | `['localhost']` | domain name whitelist |
 | usessl | `true` or `false` | set to use ssl server (if true will auto turn on `protocolusessl`) |
+| hsts | `{"enable": "true", "maxAgeSeconds": "31536000", "includeSubdomains": "true", "preload": "true"}` | [HSTS](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) options to use with HTTPS (default is the example value, max age is a year) |
 | protocolusessl | `true` or `false` | set to use ssl protocol for resources path (only applied when domain is set) |
 | urladdport | `true` or `false` | set to add port on callback url (port 80 or 443 won't applied) (only applied when domain is set) |
 | usecdn | `true` or `false` | set to use CDN resources or not (default is `true`) |

--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ Environment variables (will overwrite other server configs)
 | HMD_S3_REGION | `ap-northeast-1` | AWS S3 region |
 | HMD_S3_BUCKET | no example | AWS S3 bucket name |
 | HMD_HSTS_ENABLE | ` true`  | set to enable [HSTS](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) if HTTPS is also enabled (default is ` true`) |
+| HMD_HSTS_INCLUDE_SUBDOMAINS | `true` | set to include subdomains in HSTS (default is `true`) |
+| HMD_HSTS_MAX_AGE | `31536000` | max duration in seconds to tell clients to keep HSTS status (default is a year) |
+| HMD_HSTS_PRELOAD | `true` | whether to allow preloading of the site's HSTS status (e.g. into browsers) |
 
 Application settings `config.json`
 ---

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Environment variables (will overwrite other server configs)
 | HMD_S3_SECRET_ACCESS_KEY | no example | AWS secret key |
 | HMD_S3_REGION | `ap-northeast-1` | AWS S3 region |
 | HMD_S3_BUCKET | no example | AWS S3 bucket name |
+| HMD_HSTS_ENABLE | ` true`  | set to enable [HSTS](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) if HTTPS is also enabled (default is ` true`) |
 
 Application settings `config.json`
 ---

--- a/app.js
+++ b/app.js
@@ -97,11 +97,16 @@ var sessionStore = new SequelizeStore({
 app.use(compression())
 
 // use hsts to tell https users stick to this
-app.use(helmet.hsts({
-  maxAge: 31536000 * 1000, // 365 days
-  includeSubdomains: true,
-  preload: true
-}))
+if (config.hsts.enable) {
+  app.use(helmet.hsts({
+    maxAge: config.hsts.maxAgeSeconds * 1000,
+    includeSubdomains: config.hsts.includeSubdomains,
+    preload: config.hsts.preload
+  }))
+} else if (config.usessl) {
+  logger.info('Consider enabling HSTS for extra security:')
+  logger.info('https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security')
+}
 
 i18n.configure({
   locales: ['en', 'zh', 'fr', 'de', 'ja', 'es', 'ca', 'el', 'pt', 'it', 'tr', 'ru', 'nl', 'hr', 'pl', 'uk', 'hi', 'sv', 'eo', 'da'],

--- a/app.json
+++ b/app.json
@@ -23,7 +23,10 @@
             "description": "Specify database type. See sequelize available databases. Default using postgres",
             "value": "postgres"
         },
-
+        "HMD_HSTS_ENABLE": {
+            "description": "whether to also use HSTS if HTTPS is enabled",
+            "required": false
+        },
         "HMD_DOMAIN": {
             "description": "domain name",
             "required": false

--- a/app.json
+++ b/app.json
@@ -27,6 +27,18 @@
             "description": "whether to also use HSTS if HTTPS is enabled",
             "required": false
         },
+        "HMD_HSTS_MAX_AGE": {
+            "description": "max duration, in seconds, to tell clients to keep HSTS status",
+            "required": false
+        },
+        "HMD_HSTS_INCLUDE_SUBDOMAINS": {
+            "description": "whether to tell clients to also regard subdomains as HSTS hosts",
+            "required": false
+        },
+        "HMD_HSTS_PRELOAD": {
+            "description": "whether to allow at all adding of the site to HSTS preloads (e.g. in browsers)",
+            "required": false
+        },
         "HMD_DOMAIN": {
             "description": "domain name",
             "required": false

--- a/config.json.example
+++ b/config.json.example
@@ -6,6 +6,9 @@
         }
     },
     "development": {
+        "hsts": {
+            "enable": false
+        },
         "db": {
             "dialect": "sqlite",
             "storage": "./db.hackmd.sqlite"
@@ -13,6 +16,12 @@
     },
     "production": {
         "domain": "localhost",
+        "hsts": {
+            "enable": "true",
+            "maxAgeSeconds": "31536000",
+            "includeSubdomains": "true",
+            "preload": "true"
+        },
         "db": {
             "username": "",
             "password": "",

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -7,6 +7,12 @@ module.exports = {
   urladdport: false,
   alloworigin: ['localhost'],
   usessl: false,
+  hsts: {
+    enable: true,
+    maxAgeSeconds: 31536000,
+    includeSubdomains: true,
+    preload: true
+  },
   protocolusessl: false,
   usecdn: true,
   allowanonymous: true,

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -10,6 +10,9 @@ module.exports = {
   usessl: toBooleanConfig(process.env.HMD_USESSL),
   hsts: {
     enable: toBooleanConfig(process.env.HMD_HSTS_ENABLE),
+    maxAgeSeconds: process.env.HMD_HSTS_MAX_AGE,
+    includeSubdomains: toBooleanConfig(process.env.HMD_HSTS_INCLUDE_SUBDOMAINS),
+    preload: toBooleanConfig(process.env.HMD_HSTS_PRELOAD)
   },
   protocolusessl: toBooleanConfig(process.env.HMD_PROTOCOL_USESSL),
   alloworigin: process.env.HMD_ALLOW_ORIGIN ? process.env.HMD_ALLOW_ORIGIN.split(',') : undefined,

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -8,6 +8,9 @@ module.exports = {
   port: process.env.HMD_PORT,
   urladdport: toBooleanConfig(process.env.HMD_URL_ADDPORT),
   usessl: toBooleanConfig(process.env.HMD_USESSL),
+  hsts: {
+    enable: toBooleanConfig(process.env.HMD_HSTS_ENABLE),
+  },
   protocolusessl: toBooleanConfig(process.env.HMD_PROTOCOL_USESSL),
   alloworigin: process.env.HMD_ALLOW_ORIGIN ? process.env.HMD_ALLOW_ORIGIN.split(',') : undefined,
   usecdn: toBooleanConfig(process.env.HMD_USECDN),


### PR DESCRIPTION
This PR allows users to influence HSTS behaviour as outlined in #584. To achieve that, it adds some new configuration settings to `config.json.example` (and `lib/config/default.js`) under the `hsts` key:
````json
"hsts": {
  "enable": "true",
  "maxAgeSeconds": "31536000",
  "includeSubdomains": "true",
  "preload": "true"
}
````
These defaults should match the currently hard-coded values exactly. The maximum age is provided in seconds to improve readability while still maintaining reasonable configurability. The new options are also represented in `README.md` and `app.json`. For `README.md`, I followed the pattern of existing documentation and provided all the settings as one row, with a JSON example.

Further, this PR adds environment variables for configuring aforementioned options: `HMD_HSTS_ENABLE`, `HMD_HSTS_MAX_AGE`, `HMD_HSTS_INCLUDE_SUBDOMAINS`, and `HMD_HSTS_PRELOAD`. I wasn't quite sure on what the policy is for which settings get environment variables, so I split these changes into separate commits so that they can be easily reverted if need be.

It also logs a notice if HSTS is disabled while `usessl` is enabled.

Full disclosure, I have only tested that the app still starts and loads the configuration. I was unable to try actual HSTS behaviour and the log notice because I do not have SSL set up for this app on my local development machine. I can set it up if necessary though.