### PR TITLE
Fix markdown-it gist plugin code closing tag

### DIFF
--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -1092,7 +1092,7 @@ const gistPlugin = new Plugin(
 
     (match, utils) => {
       const gistid = match[1]
-      const code = `<code data-gist-id="${gistid}"/>`
+      const code = `<code data-gist-id="${gistid}"></code>`
       return code
     }
 )


### PR DESCRIPTION
This fix #596 

### After

![screen shot 2017-10-21 at 11 39 25 am](https://user-images.githubusercontent.com/4230968/31847830-7a3ad2fa-b5e8-11e7-9f27-e48fc3581862.png)