### PR TITLE
Externalise some trivial inline styles from slide.ejs

### DIFF
--- a/public/css/slide.css
+++ b/public/css/slide.css
@@ -258,6 +258,10 @@ pre.abc > svg {
     transform-style: preserve-3d;
 }
 
+.slides, #meta {
+    display: none;
+}
+
 .reveal .slides > section,
 .reveal .slides > section > section {
     transform-style: flat;
@@ -283,10 +287,23 @@ pre.abc > svg {
     padding: 25px 15px;
 }
 
+.footer .gray-font {
+    color: #777;
+}
+
 .footer > * {
     margin-left: auto;
     margin-right: auto;
     max-width: 758px;
+}
+
+.footer .ui-no-lastchangeuser {
+    width: 18px;
+}
+
+.footer .slides-disqus {
+    margin-top: 25px;
+    margin-bottom: 15px;
 }
 
 html, body {

--- a/public/views/slide.ejs
+++ b/public/views/slide.ejs
@@ -54,19 +54,19 @@
     <body>
         <div class="container">
             <div class="reveal">
-                <div class="slides" style="display: none;"><%= body %></div>
+                <div class="slides"><%= body %></div>
             </div>
 
-            <div id="meta" style="display: none;"><%= meta %></div>
+            <div id="meta"><%= meta %></div>
 
             <div class="footer">
-                <div class="unselectable hidden-print" style="color: #777;">
+                <div class="unselectable hidden-print gray-font">
                     <small>
                         <span>
                             <% if(lastchangeuserprofile) { %>
                                 <span class="ui-lastchangeuser">&thinsp;<i class="ui-user-icon small" style="background-image: url(<%- lastchangeuserprofile.photo %>);" data-toggle="tooltip" data-placement="right" title="<%- lastchangeuserprofile.name %>"></i></span>
                             <% } else { %>
-                                <span class="ui-no-lastchangeuser">&thinsp;<i class="fa fa-clock-o fa-fw" style="width: 18px;"></i></span>
+                                <span class="ui-no-lastchangeuser">&thinsp;<i class="fa fa-clock-o fa-fw"></i></span>
                             <% } %>
                             &nbsp;<span class="text-uppercase ui-status-lastchange"></span>
                             <span class="ui-lastchange text-uppercase" data-createtime="<%- createtime %>" data-updatetime="<%- updatetime %>"></span>
@@ -82,7 +82,7 @@
                     </small>
                 </div>
                 <% if(typeof disqus !== 'undefined' && disqus) { %>
-                <div style="margin-top: 25px; margin-bottom: 15px;">
+                <div class="slides-disqus">
                     <%- include shared/disqus %>
                 </div>
                 <% } %>


### PR DESCRIPTION
For #598, I externalised some inline styles under the impression that I could fix them all. I quickly realised that some are generated dynamically by JS or using template variables, so the effort is pointless. For all these selectors I did a code search to see if they'd clash with any other HTML, so *technically* these changes shouldn't have any side effects.

Anyways, here are the changes the the one file I did do it for. Take it or leave it, just putting this here in case it's helpful.