### PR TITLE
Fix allowpdfexport handling on error page

### DIFF
--- a/public/views/hackmd/header.ejs
+++ b/public/views/hackmd/header.ejs
@@ -70,7 +70,7 @@
                 </li>
                 <li role="presentation"><a role="menuitem" class="ui-download-raw-html" tabindex="-1" href="#" target="_self"><i class="fa fa-file-code-o fa-fw"></i> <%= __('Raw HTML') %></a>
                 </li>
-                <% if(allowpdfexport) {%>
+                <% if(typeof allowpdfexport !== 'undefined' && allowpdfexport) {%>
                   <li role="presentation"><a role="menuitem" class="ui-download-pdf-beta" tabindex="-1" href="#" target="_self"><i class="fa fa-file-pdf-o fa-fw"></i> PDF (Beta)</a>
                   </li>
                 <% } %>
@@ -171,7 +171,7 @@
                     </li>
                     <li role="presentation"><a role="menuitem" class="ui-download-raw-html" tabindex="-1" href="#" target="_self"><i class="fa fa-file-code-o fa-fw"></i> <%= __('Raw HTML') %></a>
                     </li>
-                    <% if(allowpdfexport) {%>
+                    <% if(typeof allowpdfexport !== 'undefined' && allowpdfexport) {%>
                       <li role="presentation"><a role="menuitem" class="ui-download-pdf-beta" tabindex="-1" href="#" target="_self"><i class="fa fa-file-pdf-o fa-fw"></i> PDF (Beta)</a>
                       </li>
                     <% } %>


### PR DESCRIPTION
Right now, the error page breaks because the `allowpdfexport` is not checked for existence.

