### PR TITLE
Prevent XSS vulnerbility by srcdoc in iframe

### DIFF
--- a/public/js/render.js
+++ b/public/js/render.js
@@ -18,7 +18,7 @@ whiteList['style'] = []
 // allow kbd tag
 whiteList['kbd'] = []
 // allow ifram tag with some safe attributes
-whiteList['iframe'] = ['allowfullscreen', 'name', 'referrerpolicy', 'sandbox', 'src', 'srcdoc', 'width', 'height']
+whiteList['iframe'] = ['allowfullscreen', 'name', 'referrerpolicy', 'sandbox', 'src', 'width', 'height']
 // allow summary tag
 whiteList['summary'] = []
 


### PR DESCRIPTION
Fixes #626 

I don't think there are many people using this option, so it can be safely removed.