### PR TITLE
Add setting `ldap.usernameField`

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ There are some configs you need to change in the files below
 | HMD_LDAP_SEARCHBASE | `o=users,dc=example,dc=com` | LDAP directory to begin search from |
 | HMD_LDAP_SEARCHFILTER | `(uid={{username}})` | LDAP filter to search with |
 | HMD_LDAP_SEARCHATTRIBUTES | no example | LDAP attributes to search with |
+| HMD_LDAP_USERNAMEFIELD | `uid` | The LDAP field which is used as the username on HackMD |
 | HMD_LDAP_TLS_CA | `server-cert.pem, root.pem` | Root CA for LDAP TLS in PEM format (use comma to separate) |
 | HMD_LDAP_PROVIDERNAME | `My institution` | Optional name to be displayed at login form indicating the LDAP provider |
 | HMD_SAML_IDPSSOURL | `https://idp.example.com/sso` | authentication endpoint of IdP. for details, see [guide](docs/guides/auth.md#saml-onelogin). |

--- a/config.json.example
+++ b/config.json.example
@@ -71,6 +71,7 @@
             "searchBase": "change this",
             "searchFilter": "change this",
             "searchAttributes": "change this",
+            "usernameField": "change this e.g. uid"
             "tlsOptions": {
                 "changeme": "See https://nodejs.org/api/tls.html#tls_tls_connect_options_callback"
             }

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -96,6 +96,7 @@ module.exports = {
     searchBase: undefined,
     searchFilter: undefined,
     searchAttributes: undefined,
+    usernameField: undefined,
     tlsca: undefined
   },
   saml: {

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -71,6 +71,7 @@ module.exports = {
     searchBase: process.env.HMD_LDAP_SEARCHBASE,
     searchFilter: process.env.HMD_LDAP_SEARCHFILTER,
     searchAttributes: process.env.HMD_LDAP_SEARCHATTRIBUTES,
+    usernameField: process.env.HMD_LDAP_USERNAMEFIELD,
     tlsca: process.env.HMD_LDAP_TLS_CA
   },
   saml: {

--- a/lib/web/auth/ldap/index.js
+++ b/lib/web/auth/ldap/index.js
@@ -24,9 +24,15 @@ passport.use(new LDAPStrategy({
   }
 }, function (user, done) {
   var uuid = user.uidNumber || user.uid || user.sAMAccountName
+  var username = uuid
+
+  if (config.ldap.usernameField && user[config.ldap.usernameField]) {
+    username = user[config.ldap.usernameField]
+  }
+
   var profile = {
     id: 'LDAP-' + uuid,
-    username: uuid,
+    username: username,
     displayName: user.displayName,
     emails: user.mail ? [user.mail] : [],
     avatarUrl: null,


### PR DESCRIPTION
This determines which ldap field is used as the username on
HackMD. By default, the "id" is used as username, too. The id
is taken from the fields `uidNumber`, `uid` or
`sAMAccountName`. To give the user more flexibility, they can
now choose the field used for the username instead.

---

Context: I want to use HackMD in an LDAP environment, where the ldap field chosen for the user id is just a number. Seeing a number on the top right in HackMD is a bit ugly. So with this PR, I can choose which ldap field is used as username.

I hope this PR is fine. I don't have any experience in JS. I tested this patch with my ldap server and everything runs fine.