### PR TITLE
Parse env var `HMD_LDAP_SEARCHATTRIBUTES` as a comma-separated array

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ There are some configs you need to change in the files below
 | HMD_LDAP_TOKENSECRET | `supersecretkey` | secret used for generating access/refresh tokens |
 | HMD_LDAP_SEARCHBASE | `o=users,dc=example,dc=com` | LDAP directory to begin search from |
 | HMD_LDAP_SEARCHFILTER | `(uid={{username}})` | LDAP filter to search with |
-| HMD_LDAP_SEARCHATTRIBUTES | no example | LDAP attributes to search with |
+| HMD_LDAP_SEARCHATTRIBUTES | `displayName, mail` | LDAP attributes to search with (use comma to separate) |
 | HMD_LDAP_TLS_CA | `server-cert.pem, root.pem` | Root CA for LDAP TLS in PEM format (use comma to separate) |
 | HMD_LDAP_PROVIDERNAME | `My institution` | Optional name to be displayed at login form indicating the LDAP provider |
 | HMD_SAML_IDPSSOURL | `https://idp.example.com/sso` | authentication endpoint of IdP. for details, see [guide](docs/guides/auth.md#saml-onelogin). |

--- a/config.json.example
+++ b/config.json.example
@@ -70,7 +70,7 @@
             "tokenSecret": "change this",
             "searchBase": "change this",
             "searchFilter": "change this",
-            "searchAttributes": "change this",
+            "searchAttributes": ["change this"],
             "tlsOptions": {
                 "changeme": "See https://nodejs.org/api/tls.html#tls_tls_connect_options_callback"
             }

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const {toBooleanConfig} = require('./utils')
+const {toBooleanConfig, toArrayConfig} = require('./utils')
 
 module.exports = {
   domain: process.env.HMD_DOMAIN,
@@ -15,7 +15,7 @@ module.exports = {
     preload: toBooleanConfig(process.env.HMD_HSTS_PRELOAD)
   },
   protocolusessl: toBooleanConfig(process.env.HMD_PROTOCOL_USESSL),
-  alloworigin: process.env.HMD_ALLOW_ORIGIN ? process.env.HMD_ALLOW_ORIGIN.split(',') : undefined,
+  alloworigin: toArrayConfig(process.env.HMD_ALLOW_ORIGIN),
   usecdn: toBooleanConfig(process.env.HMD_USECDN),
   allowanonymous: toBooleanConfig(process.env.HMD_ALLOW_ANONYMOUS),
   allowfreeurl: toBooleanConfig(process.env.HMD_ALLOW_FREEURL),
@@ -70,7 +70,7 @@ module.exports = {
     tokenSecret: process.env.HMD_LDAP_TOKENSECRET,
     searchBase: process.env.HMD_LDAP_SEARCHBASE,
     searchFilter: process.env.HMD_LDAP_SEARCHFILTER,
-    searchAttributes: process.env.HMD_LDAP_SEARCHATTRIBUTES,
+    searchAttributes: toArrayConfig(process.env.HMD_LDAP_SEARCHATTRIBUTES),
     tlsca: process.env.HMD_LDAP_TLS_CA
   },
   saml: {
@@ -79,8 +79,8 @@ module.exports = {
     issuer: process.env.HMD_SAML_ISSUER,
     identifierFormat: process.env.HMD_SAML_IDENTIFIERFORMAT,
     groupAttribute: process.env.HMD_SAML_GROUPATTRIBUTE,
-    externalGroups: process.env.HMD_SAML_EXTERNALGROUPS ? process.env.HMD_SAML_EXTERNALGROUPS.split('|') : [],
-    requiredGroups: process.env.HMD_SAML_REQUIREDGROUPS ? process.env.HMD_SAML_REQUIREDGROUPS.split('|') : [],
+    externalGroups: toArrayConfig(process.env.HMD_SAML_EXTERNALGROUPS, '|', []),
+    requiredGroups: toArrayConfig(process.env.HMD_SAML_REQUIREDGROUPS, '|', []),
     attribute: {
       id: process.env.HMD_SAML_ATTRIBUTE_ID,
       username: process.env.HMD_SAML_ATTRIBUTE_USERNAME,

--- a/lib/config/utils.js
+++ b/lib/config/utils.js
@@ -6,3 +6,10 @@ exports.toBooleanConfig = function toBooleanConfig (configValue) {
   }
   return configValue
 }
+
+exports.toArrayConfig = function toArrayConfig (configValue, separator = ',', fallback) {
+  if (configValue && typeof configValue === 'string') {
+    return (configValue.split(separator).map(arrayItem => arrayItem.trim()))
+  }
+  return fallback
+}


### PR DESCRIPTION
Hello!

The full context of this PR can be found in issue #649, but to reiterate:
- The [passport-ldapauth](https://github.com/vesse/passport-ldapauth#configure-strategy) strategy's `searchAttributes` field takes an array.
- Our `HMD_LDAP_SEARCHATTRIBUTES` environment variable is interpretted as a string.

This PR instead interprets `HMD_LDAP_SEARCHATTRIBUTES` as a comma-separated array.

Also to note, I've added a `toArrayConfig` function to match the `toBooleanConfig` function found in `lib/config/utils.js` and converted the existing array environment variables to also use it.

It defaults to comma `,` separators and falls back to `undefined`, but this can be overridden per-variable.

The existing pipe `|` separated variables use this override for compatibility with existing setups:
- `HMD_SAML_EXTERNALGROUPS`
- `HMD_SAML_REQUIREDGROUPS`

As per the contribution guidelines;  
Signed-off-by: Alec WM <firstcontact@owls.io>