### PR TITLE
Flip the sides of the view and edit header icons to match the UI layout

### DIFF
--- a/public/views/hackmd/header.ejs
+++ b/public/views/hackmd/header.ejs
@@ -86,14 +86,14 @@
     <div class="collapse navbar-collapse">
         <ul class="nav navbar-nav navbar-form navbar-left" style="padding:0;">
             <div class="btn-group" data-toggle="buttons">
-                <label class="btn btn-default ui-view" title="<%= __('View') %> (Ctrl+Alt+V)">
-                    <input type="radio" name="mode" autocomplete="off"><i class="fa fa-eye"></i>
+                <label class="btn btn-default ui-edit" title="<%= __('Edit') %> (Ctrl+Alt+E)">
+                    <input type="radio" name="mode" autocomplete="off"><i class="fa fa-pencil"></i>
                 </label>
                 <label class="btn btn-default ui-both" title="<%= __('Both') %> (Ctrl+Alt+B)">
                     <input type="radio" name="mode" autocomplete="off"><i class="fa fa-columns"></i>
                 </label>
-                <label class="btn btn-default ui-edit" title="<%= __('Edit') %> (Ctrl+Alt+E)">
-                    <input type="radio" name="mode" autocomplete="off"><i class="fa fa-pencil"></i>
+                <label class="btn btn-default ui-view" title="<%= __('View') %> (Ctrl+Alt+V)">
+                    <input type="radio" name="mode" autocomplete="off"><i class="fa fa-eye"></i>
                 </label>
             </div>
             <span class="btn btn-link btn-file ui-help" title="<%= __('Help') %>" data-toggle="modal" data-target=".help-modal">


### PR DESCRIPTION
From: edit on the right & view on the left
<img width="142" alt="screen shot 2018-01-03 at 2 32 45 am" src="https://user-images.githubusercontent.com/511499/34512168-881c81f4-f02e-11e7-9773-038faed88212.PNG">

To: view on the right & edit on the left 
<img width="139" alt="screen shot 2018-01-03 at 2 33 30 am" src="https://user-images.githubusercontent.com/511499/34512167-87827668-f02e-11e7-84da-ac96f3e2d437.PNG">

Because:
<img width="1028" alt="screen shot 2018-01-03 at 2 36 28 am" src="https://user-images.githubusercontent.com/511499/34512228-f075c724-f02e-11e7-8fd5-c811686fe2a6.PNG">

I spent my first few hours using HackMD confused clicking the wrong button because the sides don't match the actual layout of the sides in the UI.