### PR TITLE
Fix broken port config

### DIFF
--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -39,7 +39,7 @@ module.exports = {
     secretKey: process.env.HMD_MINIO_SECRET_KEY,
     endPoint: process.env.HMD_MINIO_ENDPOINT,
     secure: toBooleanConfig(process.env.HMD_MINIO_SECURE),
-    port: parseInt(process.env.HMD_MINIO_PORT)
+    port: process.env.HMD_MINIO_PORT
   },
   s3bucket: process.env.HMD_S3_BUCKET,
   facebook: {


### PR DESCRIPTION
The parseInt breaks the config readon from `config.json` because it results in `NaN` instead of leaving it undefined.