### PR TITLE
Remove camel case from `imageuploadtype` in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,10 +246,10 @@ There are some configs you need to change in the files below
 | documentmaxlength | `100000` | note max length |
 | email | `true` or `false` | set to allow email signin |
 | allowemailregister  | `true` or `false` | set to allow email register (only applied when email is set, default is `true`) |
-| imageUploadType | `imgur`(default), `s3`, `minio` or `filesystem` | Where to upload image
-| minio | `{ "accessKey": "YOUR_MINIO_ACCESS_KEY", "secretKey": "YOUR_MINIO_SECRET_KEY", "endpoint": "YOUR_MINIO_HOST", port: 9000, secure: true }` | When `imageUploadType` is set to `minio`, you need to set this key. Also checkout our [Minio Image Upload Guide](docs/guides/minio-image-upload.md) |
-| s3 | `{ "accessKeyId": "YOUR_S3_ACCESS_KEY_ID", "secretAccessKey": "YOUR_S3_ACCESS_KEY", "region": "YOUR_S3_REGION" }` | When `imageUploadType` be set to `s3`, you would also need to setup this key, check our [S3 Image Upload Guide](docs/guides/s3-image-upload.md) |
-| s3bucket | `YOUR_S3_BUCKET_NAME` | bucket name when `imageUploadType` is set to `s3` or `minio` |
+| imageuploadtype | `imgur`(default), `s3`, `minio` or `filesystem` | Where to upload image
+| minio | `{ "accessKey": "YOUR_MINIO_ACCESS_KEY", "secretKey": "YOUR_MINIO_SECRET_KEY", "endpoint": "YOUR_MINIO_HOST", port: 9000, secure: true }` | When `imageuploadtype` is set to `minio`, you need to set this key. Also checkout our [Minio Image Upload Guide](docs/guides/minio-image-upload.md) |
+| s3 | `{ "accessKeyId": "YOUR_S3_ACCESS_KEY_ID", "secretAccessKey": "YOUR_S3_ACCESS_KEY", "region": "YOUR_S3_REGION" }` | When `imageuploadtype` be set to `s3`, you would also need to setup this key, check our [S3 Image Upload Guide](docs/guides/s3-image-upload.md) |
+| s3bucket | `YOUR_S3_BUCKET_NAME` | bucket name when `imageuploadtype` is set to `s3` or `minio` |
 
 ## Third-party integration api key settings
 

--- a/docs/guides/minio-image-upload.md
+++ b/docs/guides/minio-image-upload.md
@@ -62,7 +62,7 @@ Minio Guide for HackMD
 8. Set upload type.
 
    ```JSON
-   "imageUploadType": "minio"
+   "imageuploadtype": "minio"
    ```
 
 9. Review your config.
@@ -78,6 +78,6 @@ Minio Guide for HackMD
        "secure": false
      },
      "s3bucket": "hackmd",
-     "imageUploadType": "minio"
+     "imageuploadtype": "minio"
    }
    ```

--- a/docs/guides/s3-image-upload.md
+++ b/docs/guides/s3-image-upload.md
@@ -63,7 +63,7 @@
     {
         "production": {
             ...
-            "imageUploadType": "s3",
+            "imageuploadtype": "s3",
             "s3": {
                 "accessKeyId": "YOUR_S3_ACCESS_KEY_ID",
                 "secretAccessKey": "YOUR_S3_ACCESS_KEY",

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -53,7 +53,9 @@ module.exports = {
   // document
   documentmaxlength: 100000,
   // image upload setting, available options are imgur/s3/filesystem
-  imageUploadType: 'filesystem',
+  imageuploadtype: 'filesystem',
+  // legacy variable name for imageuploadtype
+  imageUploadType: undefined,
   imgur: {
     clientID: undefined
   },

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -25,7 +25,7 @@ module.exports = {
   allowfreeurl: toBooleanConfig(process.env.HMD_ALLOW_FREEURL),
   defaultpermission: process.env.HMD_DEFAULT_PERMISSION,
   dburl: process.env.HMD_DB_URL,
-  imageUploadType: process.env.HMD_IMAGE_UPLOAD_TYPE,
+  imageuploadtype: process.env.HMD_IMAGE_UPLOAD_TYPE,
   imgur: {
     clientID: process.env.HMD_IMGUR_CLIENTID
   },

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -13,6 +13,7 @@ const debugConfig = {
   debug: (env === Environment.development)
 }
 
+// Get version string from package.json
 const {version} = require(path.join(appRootPath, 'package.json'))
 
 const packageConfig = {
@@ -20,7 +21,7 @@ const packageConfig = {
   minimumCompatibleVersion: '0.5.0'
 }
 
-const configFilePath = path.join(__dirname, '../../config.json')
+const configFilePath = path.join(appRootPath, 'config.json')
 const fileConfig = fs.existsSync(configFilePath) ? require(configFilePath)[env] : undefined
 
 let config = require('./default')
@@ -97,8 +98,13 @@ config.isLDAPEnable = config.ldap.url
 config.isSAMLEnable = config.saml.idpSsoUrl
 config.isPDFExportEnable = config.allowpdfexport
 
+// merge legacy values
+if (config.imageUploadType && !config.imageuploadtype) {
+  config.imageuploadtype = config.imageUploadType
+}
+
 // figure out mime types for image uploads
-switch (config.imageUploadType) {
+switch (config.imageuploadtype) {
   case 'imgur':
     config.allowedUploadMimeTypes = [
       'image/jpeg',

--- a/lib/web/imageRouter.js
+++ b/lib/web/imageRouter.js
@@ -19,7 +19,7 @@ imageRouter.post('/uploadimage', function (req, res) {
 
   form.keepExtensions = true
 
-  if (config.imageUploadType === 'filesystem') {
+  if (config.imageuploadtype === 'filesystem') {
     form.uploadDir = 'public/uploads'
   }
 
@@ -30,7 +30,7 @@ imageRouter.post('/uploadimage', function (req, res) {
       if (config.debug) { logger.info('SERVER received uploadimage: ' + JSON.stringify(files.image)) }
 
       try {
-        switch (config.imageUploadType) {
+        switch (config.imageuploadtype) {
           case 'filesystem':
             res.send({
               link: url.resolve(config.serverurl + '/', files.image.path.match(/^public\/(.+$)/)[1])


### PR DESCRIPTION
This removes the only camel cased option of the config options
**we** added to the config.json.

In auth provider's config parts are a lot of camel cased options
provided. We shouldn't touch them to keep them as similar as
possible to the examples.

Fixes #315