### PR TITLE
Fix uncaught exception for non-existent user

### DIFF
--- a/lib/web/auth/index.js
+++ b/lib/web/auth/index.js
@@ -21,6 +21,11 @@ passport.deserializeUser(function (id, done) {
       id: id
     }
   }).then(function (user) {
+    // Don't die on non-existent user
+    if (user == null) {
+      return done(null, false, { message: 'Invalid UserID' })
+    }
+
     logger.info('deserializeUser: ' + user.id)
     return done(null, user)
   }).catch(function (err) {


### PR DESCRIPTION
Since we added user management it's possible to get non-existent users
which can cause a crash of the Backend server.