### PR TITLE
don't require referer to find note id in socket.io connections (fixes #623)

### DIFF
--- a/lib/realtime.js
+++ b/lib/realtime.js
@@ -272,16 +272,24 @@ function isReady () {
 }
 
 function extractNoteIdFromSocket (socket) {
-  if (!socket || !socket.handshake || !socket.handshake.headers) {
+  if (!socket || !socket.handshake) {
     return false
   }
-  var referer = socket.handshake.headers.referer
-  if (!referer) {
+  if (socket.handshake.query && socket.handshake.query.noteId) {
+    return socket.handshake.query.noteId
+  } else if (socket.handshake.headers) {
+    // this part is only for backward compatibility only; current code
+    // should be using noteId query parameter instead.
+    var referer = socket.handshake.headers.referer
+    if (!referer) {
+      return false
+    }
+    var hostUrl = url.parse(referer)
+    var noteId = config.urlpath ? hostUrl.pathname.slice(config.urlpath.length + 1, hostUrl.pathname.length).split('/')[1] : hostUrl.pathname.split('/')[1]
+    return noteId
+  } else {
     return false
   }
-  var hostUrl = url.parse(referer)
-  var noteId = config.urlpath ? hostUrl.pathname.slice(config.urlpath.length + 1, hostUrl.pathname.length).split('/')[1] : hostUrl.pathname.split('/')[1]
-  return noteId
 }
 
 function parseNoteIdFromSocket (socket, callback) {

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1762,6 +1762,9 @@ window.havePermission = havePermission
 var io = require('socket.io-client')
 var socket = io.connect({
   path: urlpath ? '/' + urlpath + '/socket.io/' : '',
+  query: {
+    noteId: noteid
+  },
   timeout: 5000, // 5 secs to timeout,
   reconnectionAttempts: 20 // retry 20 times on connect failed
 })


### PR DESCRIPTION
I've been running with this commit (based on d1d6d5810b12645ddb02275ce0c2498b2189a8a0) for quite some time and it didn't cause any problems so far (had some users with "paranoid" browser settings which removed the referer).

When this change gets deployed all users need to reload, as otherwise the javascript running in the browser doesn't send the `noteid` query parameter while the server is expecting it.