### PR TITLE
Fix typos in migration

### DIFF
--- a/lib/migrations/20171009121200-longtext-for-mysql.js
+++ b/lib/migrations/20171009121200-longtext-for-mysql.js
@@ -4,13 +4,13 @@ module.exports = {
     queryInterface.changeColumn('Notes', 'content', {type: Sequelize.TEXT('long')})
     queryInterface.changeColumn('Revisions', 'patch', {type: Sequelize.TEXT('long')})
     queryInterface.changeColumn('Revisions', 'content', {type: Sequelize.TEXT('long')})
-    queryInterface.changeColumn('Revisions', 'latContent', {type: Sequelize.TEXT('long')})
+    queryInterface.changeColumn('Revisions', 'lastContent', {type: Sequelize.TEXT('long')})
   },
 
   down: function (queryInterface, Sequelize) {
     queryInterface.changeColumn('Notes', 'content', {type: Sequelize.TEXT})
     queryInterface.changeColumn('Revisions', 'patch', {type: Sequelize.TEXT})
     queryInterface.changeColumn('Revisions', 'content', {type: Sequelize.TEXT})
-    queryInterface.changeColumn('Revisions', 'latContent', {type: Sequelize.TEXT})
+    queryInterface.changeColumn('Revisions', 'lastContent', {type: Sequelize.TEXT})
   }
 }


### PR DESCRIPTION
This will cause migration error
```
database_1 | ERROR: column “latContent” of relation “Revisions” does not exist
database_1 | STATEMENT: ALTER TABLE “Revisions” ALTER COLUMN “latContent” DROP NOT NULL;ALTER TABLE “Revisions” ALTER COLUMN “latContent” DROP DEFAULT;ALTER TABLE “Revisions” ALTER COLUMN “latContent” TYPE TEXT;
app_1 | Unhandled rejection SequelizeDatabaseError: column “latContent” of relation “Revisions” does not exist
app_1 | at Query.formatError (/hackmd/node_modules/sequelize/lib/dialects/postgres/query.js:357:14)
app_1 | at Result.<anonymous> (/hackmd/node_modules/sequelize/lib/dialects/postgres/query.js:88:19)
app_1 | at emitOne (events.js:96:13)
app_1 | at Result.emit (events.js:188:7)
app_1 | at Result.Query.handleError (/hackmd/node_modules/pg/lib/query.js:163:8)
app_1 | at Client.<anonymous> (/hackmd/node_modules/pg/lib/client.js:188:26)
app_1 | at emitOne (events.js:96:13)
app_1 | at Connection.emit (events.js:188:7)
app_1 | at Socket.<anonymous> (/hackmd/node_modules/pg/lib/connection.js:133:12)
app_1 | at emitOne (events.js:96:13)
app_1 | at Socket.emit (events.js:188:7)
app_1 | at readableAddChunk (_stream_readable.js:176:18)
app_1 | at Socket.Readable.push (_stream_readable.js:134:10)
app_1 | at TCP.onread (net.js:547:20)
app_1 | == 20171009121200-longtext-for-mysql: migrated (0.047s)
```