### PR TITLE
Add referrer policy

### DIFF
--- a/app.js
+++ b/app.js
@@ -110,6 +110,13 @@ if (config.hsts.enable) {
   logger.info('https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security')
 }
 
+// Add referrer policy to improve privacy
+app.use(
+  helmet.referrerPolicy({
+    policy: 'same-origin'
+  })
+)
+
 // Generate a random nonce per request, for CSP with inline scripts
 app.use(csp.addNonceToLocals)
 


### PR DESCRIPTION
This commit adds a referrer policy to all requests.

The usage of `same-origin` allows HackMD to still interpret all requests
and this way not break anything. But it prevents 3rd party scripts,
pictures and more to get informations that may lead to not secured note.

It has to be mentioned that this maybe breaks some features of the
Google Analytics embedding. This has to be tested.

Fixes #724