### PR TITLE
Fix to show 500 message when got error in parseNoteId

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -146,7 +146,8 @@ function findNote (req, res, callback, include) {
   var id = req.params.noteId || req.params.shortid
   models.Note.parseNoteId(id, function (err, _id) {
     if (err) {
-      logger.log(err)
+      logger.error(err)
+      return response.errorInternalError(res)
     }
     models.Note.findOne({
       where: {


### PR DESCRIPTION
refer to: https://github.com/hackmdio/hackmd/issues/727