### PR TITLE
Allow the usage of the esc-key by codemirror

### DIFF
--- a/public/js/lib/editor/index.js
+++ b/public/js/lib/editor/index.js
@@ -18,10 +18,10 @@ export default class Editor {
         cm.setOption('fullScreen', !cm.getOption('fullScreen'))
       },
       Esc: function (cm) {
-        if (cm.getOption('keyMap').substr(0, 3) === 'vim') {
-          return CodeMirror.Pass
-        } else if (cm.getOption('fullScreen')) {
+        if (cm.getOption('fullScreen') && !(cm.getOption('keyMap').substr(0, 3) === 'vim')) {
           cm.setOption('fullScreen', false)
+        } else {
+          return CodeMirror.Pass
         }
       },
       'Cmd-S': function () {


### PR DESCRIPTION
This change allows all input modes of codemirror to use the information
from an input esc-key and make this way vim and sublime more
functional. To prevent this change from breaking the return from the
fullscreen mode, it catches the esc-key in this case. Hopefully this is
an acceptable solution.

As before the vim-mode is handled different in fulltext-mode as it is
esc-key heavy.

---

We should either fix or remove the fulltext mode as it's probably impossible to leave it right now in `vim` mode.

Fixes #738 