### PR TITLE
Extend HTML5 support by whitelisting various tags

### DIFF
--- a/public/css/markdown.css
+++ b/public/css/markdown.css
@@ -188,3 +188,12 @@
 .markdown-body .alert > ul {
     margin-bottom: 0;
 }
+
+/* Make details boxes look like on GitHub */
+.markdown-body details summary {
+    cursor: pointer;
+}
+
+.markdown-body summary {
+    display: list-item;
+}

--- a/public/js/render.js
+++ b/public/js/render.js
@@ -19,8 +19,18 @@ whiteList['style'] = []
 whiteList['kbd'] = []
 // allow ifram tag with some safe attributes
 whiteList['iframe'] = ['allowfullscreen', 'name', 'referrerpolicy', 'sandbox', 'src', 'width', 'height']
-// allow summary tag
+// allow details tag
+whiteList['details'] = []
+// allow summary tag for details
 whiteList['summary'] = []
+// allow ruby tag
+whiteList['ruby'] = []
+// allow rt tag for ruby
+whiteList['rt'] = []
+// allow figure tag
+whiteList['figure'] = []
+// allow figcaption tag
+whiteList['figcaption'] = []
 
 var filterXSSOptions = {
   allowCommentTag: true,


### PR DESCRIPTION
HTML5 provides a wide feature set of useful elements. Since Markdown
usually supports HTML it should be able to use these HTML5 tags as well.
As they were requested by some users and they where checked for being
safe, whitelisting them isn't a problem. To make the experience the same
as on GitHub when it comes to the basic look and feel of the rendered
markdown, some CSS was added to make the summary and the details tag
look like on GitHub.

---

Fixes #671