### PR TITLE
Support more html5 tags and styles

### DIFF
--- a/public/css/markdown.css
+++ b/public/css/markdown.css
@@ -190,10 +190,22 @@
 }
 
 /* Make details boxes look like on GitHub */
+.markdown-body summary {
+    display: list-item;
+}
+
+.markdown-body summary:focus {
+    outline: none;
+}
+
 .markdown-body details summary {
     cursor: pointer;
 }
 
-.markdown-body summary {
-    display: list-item;
+.markdown-body details:not([open]) > *:not(summary) {
+    display: none;
+}
+
+.markdown-body figure {
+    margin: 1em 40px;
 }

--- a/public/js/render.js
+++ b/public/js/render.js
@@ -19,9 +19,7 @@ whiteList['style'] = []
 whiteList['kbd'] = []
 // allow ifram tag with some safe attributes
 whiteList['iframe'] = ['allowfullscreen', 'name', 'referrerpolicy', 'sandbox', 'src', 'width', 'height']
-// allow details tag
-whiteList['details'] = []
-// allow summary tag for details
+// allow summary tag
 whiteList['summary'] = []
 // allow ruby tag
 whiteList['ruby'] = []

--- a/public/js/render.js
+++ b/public/js/render.js
@@ -23,6 +23,8 @@ whiteList['iframe'] = ['allowfullscreen', 'name', 'referrerpolicy', 'sandbox', '
 whiteList['summary'] = []
 // allow ruby tag
 whiteList['ruby'] = []
+// allow rp tag for ruby
+whiteList['rp'] = []
 // allow rt tag for ruby
 whiteList['rt'] = []
 // allow figure tag


### PR DESCRIPTION
As https://github.com/hackmdio/hackmd/pull/740 mentioned
This PR add support of `rp` and allow `open` attribute of `details` tag.
Update styles for `details`, `summary` and `figure` tags.