### PR TITLE
Use ldap.usernameField over hardcoded uid fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ There are some config settings you need to change in the files below.
 | `HMD_LDAP_SEARCHBASE` | `o=users,dc=example,dc=com` | LDAP directory to begin search from |
 | `HMD_LDAP_SEARCHFILTER` | `(uid={{username}})` | LDAP filter to search with |
 | `HMD_LDAP_SEARCHATTRIBUTES` | `displayName, mail` | LDAP attributes to search with (use comma to separate) |
-| `HMD_LDAP_USERNAMEFIELD` | `uid` | The LDAP field which is used as the username on HackMD |
+| `HMD_LDAP_USERIDFIELD` | `uidNumber` or `uid` or `sAMAccountName` | The LDAP field which is used uniquely identify a user on HackMD |
+| `HMD_LDAP_USERNAMEFIELD` | Fallback to userid | The LDAP field which is used as the username on HackMD |
 | `HMD_LDAP_TLS_CA` | `server-cert.pem, root.pem` | Root CA for LDAP TLS in PEM format (use comma to separate) |
 | `HMD_LDAP_PROVIDERNAME` | `My institution` | Optional name to be displayed at login form indicating the LDAP provider |
 | `HMD_SAML_IDPSSOURL` | `https://idp.example.com/sso` | authentication endpoint of IdP. for details, see [guide](docs/guides/auth.md#saml-onelogin). |

--- a/config.json.example
+++ b/config.json.example
@@ -78,7 +78,8 @@
             "searchBase": "change this",
             "searchFilter": "change this",
             "searchAttributes": ["change this"],
-            "usernameField": "change this e.g. uid",
+            "usernameField": "change this e.g. cn",
+            "useridField": "change this e.g. uid",
             "tlsOptions": {
                 "changeme": "See https://nodejs.org/api/tls.html#tls_tls_connect_options_callback"
             }

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -115,6 +115,7 @@ module.exports = {
     searchFilter: undefined,
     searchAttributes: undefined,
     usernameField: undefined,
+    useridField: undefined,
     tlsca: undefined
   },
   saml: {

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -84,6 +84,7 @@ module.exports = {
     searchFilter: process.env.HMD_LDAP_SEARCHFILTER,
     searchAttributes: toArrayConfig(process.env.HMD_LDAP_SEARCHATTRIBUTES),
     usernameField: process.env.HMD_LDAP_USERNAMEFIELD,
+    useridField: process.env.HMD_LDAP_USERIDFIELD,
     tlsca: process.env.HMD_LDAP_TLS_CA
   },
   saml: {

--- a/lib/web/auth/ldap/index.js
+++ b/lib/web/auth/ldap/index.js
@@ -24,8 +24,11 @@ passport.use(new LDAPStrategy({
   }
 }, function (user, done) {
   var uuid = user.uidNumber || user.uid || user.sAMAccountName
-  var username = uuid
+  if (config.ldap.useridField && user[config.ldap.useridField]) {
+    uuid = user[config.ldap.useridField]
+  }
 
+  var username = uuid
   if (config.ldap.usernameField && user[config.ldap.usernameField]) {
     username = user[config.ldap.usernameField]
   }


### PR DESCRIPTION
In our environment we don't have `uid` set on users. This leads to all users share the same profile called `LDAP-undefined`.

This fixes this under the assumption that usernames are unique anyways. 