### PR TITLE
Multiple emails from LDAP are already an Array

### DIFF
--- a/lib/web/auth/ldap/index.js
+++ b/lib/web/auth/ldap/index.js
@@ -37,7 +37,7 @@ passport.use(new LDAPStrategy({
     id: 'LDAP-' + uuid,
     username: username,
     displayName: user.displayName,
-    emails: user.mail ? [user.mail] : [],
+    emails: user.mail ? Array.isArray(user.mail) ? user.mail : [user.mail] : [],
     avatarUrl: null,
     profileUrl: null,
     provider: 'ldap'


### PR DESCRIPTION
When a user has multiple email addresses in LDAP, the returned value is already and `Array`, re-wrapping causes the gravatar lookup to use the inner array of emails and failing to present the proper gravatar of the user.