### PR TITLE
Add config option for report URI in CSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ There are some config settings you need to change in the files below.
 | `HMD_HSTS_MAX_AGE` | `31536000` | max duration in seconds to tell clients to keep HSTS status (default is a year) |
 | `HMD_HSTS_PRELOAD` | `true` | whether to allow preloading of the site's HSTS status (e.g. into browsers) |
 | `HMD_CSP_ENABLE` | `true` | whether to enable Content Security Policy (directives cannot be configured with environment variables) |
+| `HMD_CSP_REPORTURI` | `https://<someid>.report-uri.com/r/d/csp/enforce` | Allows to add a URL for CSP reports in case of violations |
 
 ## Application settings `config.json`
 

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -18,7 +18,8 @@ module.exports = {
     directives: {
     },
     addDefaults: true,
-    upgradeInsecureRequests: 'auto'
+    upgradeInsecureRequests: 'auto',
+    reportURI: undefined
   },
   protocolusessl: false,
   usecdn: true,

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -15,7 +15,8 @@ module.exports = {
     preload: toBooleanConfig(process.env.HMD_HSTS_PRELOAD)
   },
   csp: {
-    enable: toBooleanConfig(process.env.HMD_CSP_ENABLE)
+    enable: toBooleanConfig(process.env.HMD_CSP_ENABLE),
+    reportURI: process.env.HMD_CSP_REPORTURI
   },
   protocolusessl: toBooleanConfig(process.env.HMD_PROTOCOL_USESSL),
   alloworigin: toArrayConfig(process.env.HMD_ALLOW_ORIGIN),

--- a/lib/csp.js
+++ b/lib/csp.js
@@ -30,6 +30,7 @@ CspStrategy.computeDirectives = function () {
     addInlineScriptExceptions(directives)
   }
   addUpgradeUnsafeRequestsOptionTo(directives)
+  addReportURI(directives)
   return directives
 }
 
@@ -69,6 +70,12 @@ function addUpgradeUnsafeRequestsOptionTo (directives) {
     directives.upgradeInsecureRequests = true
   } else if (config.csp.upgradeInsecureRequests === true) {
     directives.upgradeInsecureRequests = true
+  }
+}
+
+function addReportURI (directives) {
+  if (config.csp.reportURI) {
+    directives.reportUri = config.csp.reportURI
   }
 }
 


### PR DESCRIPTION
This option is needed as it's currently not possible to add an report
URI by the directives array. This option also allows to get CSP reports
not only on docker based setup but also on our heroku instances.

Improves CSP support #594 