### PR TITLE
Fix minio port been NaN while  HMD_MINIO_PORT  isn't set in ENV #767

### DIFF
--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -40,7 +40,7 @@ module.exports = {
     secretKey: process.env.HMD_MINIO_SECRET_KEY,
     endPoint: process.env.HMD_MINIO_ENDPOINT,
     secure: toBooleanConfig(process.env.HMD_MINIO_SECURE),
-    port: parseInt(process.env.HMD_MINIO_PORT)
+    port: (process.env.HMD_MINIO_PORT == undefined) ? undefined : parseInt(process.env.HMD_MINIO_PORT)
   },
   s3bucket: process.env.HMD_S3_BUCKET,
   facebook: {


### PR DESCRIPTION
fix hackmdio/hackmd#767
---
`port: parseInt(process.env.HMD_MINIO_PORT)` will make `config.minio.port` be ***NaN*** while `HMD_MINIO_PORT` hasn't set in ENV .   And It brings on that port value in `config.json` doesn't work because `lodash.merge` only skip  **undefined** value .

Therefore , value of minio port should be **undefined** when `HMD_MINIO_PORT` isn't set to prevent original value be overwrote with **NaN** .
