### PR TITLE
Add check for undefined UUID

### DIFF
--- a/lib/web/auth/ldap/index.js
+++ b/lib/web/auth/ldap/index.js
@@ -23,9 +23,16 @@ passport.use(new LDAPStrategy({
     tlsOptions: config.ldap.tlsOptions || null
   }
 }, function (user, done) {
-  var uuid = user.uidNumber || user.uid || user.sAMAccountName
+  var uuid = user.uidNumber || user.uid || user.sAMAccountName || undefined
   if (config.ldap.useridField && user[config.ldap.useridField]) {
     uuid = user[config.ldap.useridField]
+  }
+
+  if (typeof uuid === 'undefined') {
+    throw new Error('Could not determine UUID for LDAP user. Check that ' +
+    'either uidNumber, uid or sAMAccountName is set in your LDAP directory ' +
+    'or use another unique attribute and configure it using the ' +
+    '"useridField" option in ldap settings.')
   }
 
   var username = uuid


### PR DESCRIPTION
This check is needed at there are tons of LDAP implementations out there
and none has at least one guaranteed unique field. As we currently check
three fields and added an option to select one yourself, it's still not
said that any of these fields is set. This will now create an error
and fail the authentication instead of letting people may get access to
other people's notes which are stored under a this way deterministic
wrong userid named `LDAP-undefined`.

Fixes #764 

@fooker would you like to review and test this?