### PR TITLE
Fix night mode button after restore

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -451,6 +451,7 @@ $(document).ready(function () {
   // Re-enable nightmode
   if (store.get('nightMode') || Cookies.get('nightMode')) {
     $body.addClass('night')
+    ui.toolbar.night.addClass('active')
   }
 
   // showup


### PR DESCRIPTION
The night mode toggle doesn't get the right state after restore from
local storage. This results in the need to toggle twice to disable night
mode.

This patch adds the needed class so the `toggleNightMode` function gets
the right state on execution.