### PR TITLE
Allow embedding of video and audio tags

### DIFF
--- a/lib/csp.js
+++ b/lib/csp.js
@@ -11,6 +11,7 @@ var defaultDirectives = {
   styleSrc: ['\'self\'', '\'unsafe-inline\'', 'https://assets-cdn.github.com'], // unsafe-inline is required for some libs, plus used in views
   fontSrc: ['\'self\'', 'https://public.slidesharecdn.com'],
   objectSrc: ['*'], // Chrome PDF viewer treats PDFs as objects :/
+  mediaSrc: ['*'],
   childSrc: ['*'],
   connectSrc: ['*']
 }


### PR DESCRIPTION
Adding mediaSrc to CSP so video and audio files can be embedded without
problems.

From a security perspective it should be fine to load audio and video
data without introducing a high security issue. Only from a privacy
perspective it allows another way to track users if there are data
embedded. But it doesn't introduce any new attack vector as pictures are
also allowed from everywhere.