### PR TITLE
Automatically generate a session secret if default is used

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -46,6 +46,7 @@ module.exports = {
   // session
   sessionName: 'connect.sid',
   sessionSecret: 'secret',
+  sessionSecretLen: 128,
   sessionLife: 14 * 24 * 60 * 60 * 1000, // 14 days
   staticCacheTime: 1 * 24 * 60 * 60 * 1000, // 1 day
   // socket.io

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1,6 +1,7 @@
 
 'use strict'
 
+const crypto = require('crypto')
 const fs = require('fs')
 const path = require('path')
 const {merge} = require('lodash')
@@ -115,6 +116,14 @@ for (let i = keys.length; i--;) {
     logger.warn('config.js contains deprecated lowercase setting for ' + keys[i] + '. Please change your config.js file to replace ' + lowercaseKey + ' with ' + keys[i])
     config[keys[i]] = config[lowercaseKey]
   }
+}
+
+// Generate session secret if it stays on default values
+if (config.sessionSecret === 'secret') {
+  logger.warn('Session secret not set. Using random generated one. Please set `sessionSecret` in your config.js file. All users will be logged out.')
+  config.sessionSecret = crypto.randomBytes(Math.ceil(config.sessionSecretLen / 2)) // generate crypto graphic random number
+        .toString('hex')                                                            // convert to hexadecimal format
+        .slice(0, config.sessionSecretLen)                                           // return required number of characters
 }
 
 // Validate upload upload providers


### PR DESCRIPTION
The session secret is used to sign and authenticate the session cookie
and this way very important for the authentication process.

By default the session secret is set to `secret` and never changes. This
commit will add a generator for a dynamic session secret if it stays
unchanges.

It prevents session hijacking this way and will warn the user about
the missing secret.

This also implies that on a restart without configured session secret
will log out all users. While it may seems annoying, it's for the users
best.