### PR TITLE
Add title attribute in table of contents

### DIFF
--- a/public/vendor/md-toc.js
+++ b/public/vendor/md-toc.js
@@ -54,6 +54,7 @@
       var j = i + 1
       this._elTitleElement = this.elTitleElements[i]
       this._elTitleElementName = this._elTitleElement.tagName
+      this._elTitleElementTitle = this._elTitleElement.textContent.replace(/"/g, '&quot;')
       this._elTitleElementText = (typeof this.process === 'function' ? this.process(this._elTitleElement) : this._elTitleElement.innerHTML).replace(/<(?:.|\n)*?>/gm, '')
       var id = this._elTitleElement.getAttribute('id')
       if (!id) {
@@ -63,7 +64,7 @@
         id = '#' + id
       }
 
-      this.tocContent += '<li><a href="' + id + '">' + this._elTitleElementText + '</a>'
+      this.tocContent += '<li><a href="' + id + '" title="'+ this._elTitleElementTitle +'">' + this._elTitleElementText + '</a>'
 
       if (j !== this._elTitleElementsLen) {
         this._elNextTitleElementName = this.elTitleElements[j].tagName


### PR DESCRIPTION
Right now the full title of an element is may not shown as the space of
the ToC is limited. With this path it'll be shower on hover and this way
provide more useful information.

Fixes #781 