### PR TITLE
Add "generic" OAuth2 support

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -72,6 +72,12 @@ module.exports = {
   },
   s3bucket: undefined,
   // authentication
+  oauth2: {
+    authorizationURL: undefined,
+    tokenURL: undefined,
+    clientID: undefined,
+    clientSecret: undefined
+  },
   facebook: {
     clientID: undefined,
     clientSecret: undefined

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -66,6 +66,17 @@ module.exports = {
     clientID: process.env.HMD_MATTERMOST_CLIENTID,
     clientSecret: process.env.HMD_MATTERMOST_CLIENTSECRET
   },
+  oauth2: {
+    baseURL: process.env.HMD_OAUTH2_BASEURL,
+    userProfileURL: process.env.HMD_OAUTH2_USER_PROFILE_URL,
+    userProfileUsernameAttr: process.env.HMD_OAUTH2_USER_PROFILE_USERNAME_ATTR,
+    userProfileDisplayNameAttr: process.env.HMD_OAUTH2_USER_PROFILE_DISPLAY_NAME_ATTR,
+    userProfileEmailAttr: process.env.HMD_OAUTH2_USER_PROFILE_EMAIL_ATTR,
+    tokenURL: process.env.HMD_OAUTH2_TOKEN_URL,
+    authorizationURL: process.env.HMD_OAUTH2_AUTHORIZATION_URL,
+    clientID: process.env.HMD_OAUTH2_CLIENT_ID,
+    clientSecret: process.env.HMD_OAUTH2_CLIENT_SECRET
+  },
   dropbox: {
     clientID: process.env.HMD_DROPBOX_CLIENTID,
     clientSecret: process.env.HMD_DROPBOX_CLIENTSECRET,

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -98,6 +98,7 @@ config.isGitLabEnable = config.gitlab.clientID && config.gitlab.clientSecret
 config.isMattermostEnable = config.mattermost.clientID && config.mattermost.clientSecret
 config.isLDAPEnable = config.ldap.url
 config.isSAMLEnable = config.saml.idpSsoUrl
+config.isOAuth2Enable = config.oauth2.clientID && config.oauth2.clientSecret
 config.isPDFExportEnable = config.allowPDFExport
 
 // merge legacy values

--- a/lib/migrations/20180326103000-use-text-in-tokens.js
+++ b/lib/migrations/20180326103000-use-text-in-tokens.js
@@ -1,0 +1,23 @@
+'use strict'
+
+module.exports = {
+  up: function (queryInterface, Sequelize) {
+    return queryInterface.changeColumn('Users', 'accessToken', {
+      type: Sequelize.TEXT
+    }).then(function () {
+      return queryInterface.changeColumn('Users', 'refreshToken', {
+        type: Sequelize.TEXT
+      })
+    })
+  },
+
+  down: function (queryInterface, Sequelize) {
+    return queryInterface.changeColumn('Users', 'accessToken', {
+      type: Sequelize.STRING
+    }).then(function () {
+      return queryInterface.changeColumn('Users', 'refreshToken', {
+        type: Sequelize.STRING
+      })
+    })
+  }
+}

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -26,10 +26,10 @@ module.exports = function (sequelize, DataTypes) {
       type: DataTypes.TEXT
     },
     accessToken: {
-      type: DataTypes.STRING
+      type: DataTypes.TEXT
     },
     refreshToken: {
-      type: DataTypes.STRING
+      type: DataTypes.TEXT
     },
     email: {
       type: Sequelize.TEXT,

--- a/lib/response.js
+++ b/lib/response.js
@@ -70,6 +70,8 @@ function showIndex (req, res, next) {
     ldap: config.isLDAPEnable,
     ldapProviderName: config.ldap.providerName,
     saml: config.isSAMLEnable,
+    oauth2: config.isOAuth2Enable,
+    oauth2ProviderName: config.oauth2.providerName,
     email: config.isEmailEnable,
     allowEmailRegister: config.allowEmailRegister,
     allowPDFExport: config.allowPDFExport,
@@ -104,7 +106,9 @@ function responseHackMD (res, note) {
     google: config.isGoogleEnable,
     ldap: config.isLDAPEnable,
     ldapProviderName: config.ldap.providerName,
+    oauth2ProviderName: config.oauth2.providerName,
     saml: config.isSAMLEnable,
+    oauth2: config.isOAuth2Enable,
     email: config.isEmailEnable,
     allowEmailRegister: config.allowEmailRegister,
     allowPDFExport: config.allowPDFExport

--- a/lib/web/auth/index.js
+++ b/lib/web/auth/index.js
@@ -43,6 +43,7 @@ if (config.isDropboxEnable) authRouter.use(require('./dropbox'))
 if (config.isGoogleEnable) authRouter.use(require('./google'))
 if (config.isLDAPEnable) authRouter.use(require('./ldap'))
 if (config.isSAMLEnable) authRouter.use(require('./saml'))
+if (config.isOAuth2Enable) authRouter.use(require('./oauth2'))
 if (config.isEmailEnable) authRouter.use(require('./email'))
 
 // logout

--- a/lib/web/auth/oauth2/index.js
+++ b/lib/web/auth/oauth2/index.js
@@ -1,0 +1,106 @@
+'use strict'
+
+const Router = require('express').Router
+const passport = require('passport')
+const OAuth2Strategy = require('passport-oauth2').Strategy
+const config = require('../../../config')
+const {setReturnToFromReferer, passportGeneralCallback} = require('../utils')
+
+let oauth2Auth = module.exports = Router()
+
+class OAuth2CustomStrategy extends OAuth2Strategy {
+  constructor (options, verify) {
+    options.customHeaders = options.customHeaders || {}
+    super(options, verify)
+    this.name = 'oauth2'
+    this._userProfileURL = options.userProfileURL
+    this._oauth2.useAuthorizationHeaderforGET(true)
+  }
+
+  userProfile (accessToken, done) {
+    this._oauth2.get(this._userProfileURL, accessToken, function (err, body, res) {
+      var json
+
+      if (err) {
+        return done(new passport.InternalOAuthError('Failed to fetch user profile', err))
+      }
+
+      try {
+        json = JSON.parse(body)
+      } catch (ex) {
+        return done(new Error('Failed to parse user profile'))
+      }
+
+      let profile = parseProfile(json)
+      profile.provider = 'oauth2'
+
+      done(null, profile)
+    })
+  }
+}
+
+function extractProfileAttribute (data, path) {
+  // can handle stuff like `attrs[0].name`
+  path = path.split('.')
+  for (const segment of path) {
+    const m = segment.match(/([\d\w]+)\[(.*)\]/)
+    data = m ? data[m[1]][m[2]] : data[segment]
+  }
+  return data
+}
+
+function parseProfile (data) {
+  const username = extractProfileAttribute(data, config.oauth2.userProfileUsernameAttr)
+  const displayName = extractProfileAttribute(data, config.oauth2.userProfileDisplayNameAttr)
+  const email = extractProfileAttribute(data, config.oauth2.userProfileEmailAttr)
+
+  return {
+    id: username,
+    username: username,
+    displayName: displayName,
+    email: email
+  }
+}
+
+OAuth2CustomStrategy.prototype.userProfile = function (accessToken, done) {
+  this._oauth2.get(this._userProfileURL, accessToken, function (err, body, res) {
+    var json
+
+    if (err) {
+      return done(new passport.InternalOAuthError('Failed to fetch user profile', err))
+    }
+
+    try {
+      json = JSON.parse(body)
+    } catch (ex) {
+      return done(new Error('Failed to parse user profile'))
+    }
+
+    let profile = parseProfile(json)
+    profile.provider = 'oauth2'
+
+    done(null, profile)
+  })
+}
+
+passport.use(new OAuth2CustomStrategy({
+  authorizationURL: config.oauth2.authorizationURL,
+  tokenURL: config.oauth2.tokenURL,
+  clientID: config.oauth2.clientID,
+  clientSecret: config.oauth2.clientSecret,
+  callbackURL: config.serverURL + '/auth/oauth2/callback',
+  userProfileURL: config.oauth2.userProfileURL
+}, passportGeneralCallback))
+
+oauth2Auth.get('/auth/oauth2', function (req, res, next) {
+  setReturnToFromReferer(req)
+  passport.authenticate('oauth2')(req, res, next)
+})
+
+// github auth callback
+oauth2Auth.get('/auth/oauth2/callback',
+  passport.authenticate('oauth2', {
+    successReturnToOrRedirect: config.serverurl + '/',
+    failureRedirect: config.serverurl + '/'
+  })
+)

--- a/public/views/index/body.ejs
+++ b/public/views/index/body.ejs
@@ -15,7 +15,7 @@
                                 <% if(allowAnonymous) { %>
                                 <a type="button" href="<%- url %>/new" class="btn btn-sm btn-primary"><i class="fa fa-plus"></i> <%= __('New guest note') %></a>
                                 <% } %>
-                                <% if(facebook || twitter || github || gitlab || mattermost || dropbox || google || ldap || saml || email) { %>
+                                <% if(facebook || twitter || github || gitlab || mattermost || dropbox || google || ldap || saml || oauth2 || email) { %>
                                 <button class="btn btn-sm btn-success ui-signin" data-toggle="modal" data-target=".signin-modal"><%= __('Sign In') %></button>
                                 <% } %>
                             </div>
@@ -49,7 +49,7 @@
                     <% if (errorMessage && errorMessage.length > 0) { %>
                     <div class="alert alert-danger" style="max-width: 400px; margin: 0 auto;"><%= errorMessage %></div>
                     <% } %>
-                    <% if(facebook || twitter || github || gitlab || mattermost || dropbox || google || ldap || saml || email) { %>
+                    <% if(facebook || twitter || github || gitlab || mattermost || dropbox || google || ldap || saml || oauth2 || email) { %>
                     <span class="ui-signin">
                         <br>
                         <a type="button" class="btn btn-lg btn-success ui-signin" data-toggle="modal" data-target=".signin-modal" style="min-width: 200px;"><%= __('Sign In') %></a>

--- a/public/views/shared/signin-modal.ejs
+++ b/public/views/shared/signin-modal.ejs
@@ -48,7 +48,12 @@
                     <i class="fa fa-users"></i> <%= __('Sign in via %s', 'SAML') %>
                 </a>
                 <% } %>
-                <% if((facebook || twitter || github || gitlab || mattermost || dropbox || google || saml) && ldap) { %>
+                <% if(oauth2) { %>
+                <a href="<%- url %>/auth/oauth2" class="btn btn-lg btn-block btn-social btn-soundcloud">
+                    <i class="fa fa-mail-forward"></i> <%= __('Sign in via %s', oauth2ProviderName || 'OAuth2') %>
+                </a>
+                <% } %>
+                <% if((facebook || twitter || github || gitlab || mattermost || dropbox || google || saml || oauth2) && ldap) { %>
                 <hr>
                 <% }%>
                 <% if(ldap) { %>
@@ -73,7 +78,7 @@
                     </div>
                 </form>
                 <% } %>
-                <% if((facebook || twitter || github || gitlab || mattermost || dropbox || google || ldap) && email) { %>
+                <% if((facebook || twitter || github || gitlab || mattermost || dropbox || google || ldap || oauth2) && email) { %>
                 <hr>
                 <% }%>
                 <% if(email) { %>


### PR DESCRIPTION
The currently available OAuth methods are limited to a few providers. This PR implements a "generic" OAuth workflow which will fetch user profile info from a given JSON endpoint and extract a set of configurable fields. Example:

```json
        "oauth2": {
          "clientID": "test_hackmd_notasbad",
          "clientSecret": "lc05GbmUT5crF33341CcpDbliG8KNW0HS4p9sS91Vx81",
          "authorizationURL": "https://authprovider/oauth/authorize",
          "tokenURL": "https://authprovider/oauth/token",
          "userProfileURL": "https://authprovider/api/user",
          "userProfileUsernameAttr": "username",
          "userProfileDisplayNameAttr": "data.displayName",
          "userProfileEmailAttr": "email"
        }
```

I tried to guide myself by the existing OAuth provider definitions, please let me know if there are any better ways of doing what I'm trying to do.