### PR TITLE
403: Redirect user to login page if not logged in

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -17,7 +17,13 @@ var utils = require('./utils')
 // public
 var response = {
   errorForbidden: function (res) {
-    responseError(res, '403', 'Forbidden', 'oh no.')
+    const {req} = res
+    if (req.user) {
+      responseError(res, '403', 'Forbidden', 'oh no.')
+    } else {
+      req.flash('error', 'You are not allowed to access this page. Maybe try logging in?')
+      res.redirect(config.serverURL)
+    }
   },
   errorNotFound: function (res) {
     responseError(res, '404', 'Not Found', 'oops.')


### PR DESCRIPTION
It's slightly annoying and confusing that I get a 403 error page for a note I can't access, even if I'm not logged in. A common solution in other apps seems to be redirecting the user to the login page. Since there doesn't seem to be a URL I can send the user to in this case, I redirect them to the home page and flash a message asking them to log in.