### PR TITLE
Fix some issues with legacy config compatiblity

### DIFF
--- a/lib/config/defaultSSL.js
+++ b/lib/config/defaultSSL.js
@@ -10,8 +10,8 @@ function getFile (path) {
 }
 
 module.exports = {
-  sslkeypath: getFile('/run/secrets/key.pem'),
-  sslcertpath: getFile('/run/secrets/cert.pem'),
-  sslcapath: getFile('/run/secrets/ca.pem') !== undefined ? [getFile('/run/secrets/ca.pem')] : [],
-  dhparampath: getFile('/run/secrets/dhparam.pem')
+  sslKeyPath: getFile('/run/secrets/key.pem'),
+  sslCertPath: getFile('/run/secrets/cert.pem'),
+  sslCAPath: getFile('/run/secrets/ca.pem') !== undefined ? [getFile('/run/secrets/ca.pem')] : [],
+  dhParamPath: getFile('/run/secrets/dhparam.pem')
 }

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -110,8 +110,8 @@ for (let i = keys.length; i--;) {
   // and the config with uppercase is not set
   // we set the new config using the old key.
   if (uppercase.test(keys[i]) &&
-  config[lowercaseKey] &&
-  !config[keys[1]]) {
+  config[lowercaseKey] !== undefined &&
+  fileConfig[keys[i]] === undefined) {
     logger.warn('config.js contains deprecated lowercase setting for ' + keys[i] + '. Please change your config.js file to replace ' + lowercaseKey + ' with ' + keys[i])
     config[keys[i]] = config[lowercaseKey]
   }


### PR DESCRIPTION
After discovering some issues with the usage of the old config variables, these fixes should correct the missing pieces.

sslCAPath should be set correctly now

And all legacy configs set to false and all default configs set to true should also be overwritten now.