### PR TITLE
Add session data to env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ There are some config settings you need to change in the files below.
 | `HMD_ALLOW_FREEURL` | `true` or `false` | set to allow new note creation by accessing a nonexistent note URL |
 | `HMD_DEFAULT_PERMISSION` | `freely`, `editable`, `limited`, `locked` or `private` | set notes default permission (only applied on signed users) |
 | `HMD_DB_URL` | `mysql://localhost:3306/database` | set the database URL |
+| `HMD_SESSION_SECRET` | no example | Secret used to sign the session cookie. If non is set, one will randomly generated on startup |
+| `HMD_SESSION_LIFE` | `1209600000` | Session life time. (milliseconds) |
 | `HMD_FACEBOOK_CLIENTID` | no example | Facebook API client id |
 | `HMD_FACEBOOK_CLIENTSECRET` | no example | Facebook API client secret |
 | `HMD_TWITTER_CONSUMERKEY` | no example | Twitter API consumer key |

--- a/app.json
+++ b/app.json
@@ -23,6 +23,10 @@
             "description": "Specify database type. See sequelize available databases. Default using postgres",
             "value": "postgres"
         },
+        "HMD_SESSION_SECRET": {
+            "description": "Secret used to secure session cookies.",
+            "required": false
+        },
         "HMD_HSTS_ENABLE": {
             "description": "whether to also use HSTS if HTTPS is enabled",
             "required": false

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -26,6 +26,8 @@ module.exports = {
   allowFreeURL: toBooleanConfig(process.env.HMD_ALLOW_FREEURL),
   defaultPermission: process.env.HMD_DEFAULT_PERMISSION,
   dbURL: process.env.HMD_DB_URL,
+  sessionSecret: process.env.HMD_SESSION_SECRET,
+  sessionLife: toIntegerConfig(process.env.HMD_SESSION_LIFE),
   imageUploadType: process.env.HMD_IMAGE_UPLOAD_TYPE,
   imgur: {
     clientID: process.env.HMD_IMGUR_CLIENTID


### PR DESCRIPTION
Currently the session secret can only be set by config.json or docker
secrets. This creates a problem on Heroku hosted instances that can not
set a session secret.

Since we automatically generate them on startup this results in an
logout of all users on every config change in Heroku.