### PR TITLE
Add matrix.org / Riot link

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -62,7 +62,7 @@
 	"Refresh": "Neu laden",
 	"Contacts": "Kontakte",
 	"Report an issue": "Fehlerbericht senden",
-	"Meet us on Gitter": "Triff uns auf Gitter",
+	"Meet us on %s": "Triff uns auf %s",
 	"Send us email": "Kontakt",
 	"Documents": "Dokumente",
 	"Features": "Funktionen",

--- a/locales/en.json
+++ b/locales/en.json
@@ -62,7 +62,7 @@
 	"Refresh": "Refresh",
 	"Contacts": "Contacts",
 	"Report an issue": "Report an issue",
-	"Meet us on Gitter": "Meet us on Gitter",
+	"Meet us on %s": "Meet us on %s",
 	"Send us email": "Send us email",
 	"Documents": "Documents",
 	"Features": "Features",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -60,7 +60,7 @@
 	"Refresh": "重新整理",
 	"Contacts": "联络方式",
 	"Report an issue": "报告问题",
-	"Meet us on Gitter": "在 Gitter 上联系我们",
+	"Meet us on %s": "在 %s 上联系我们",
 	"Send us email": "寄信给我们",
 	"Documents": "文件",
 	"Features": "功能简介",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -60,7 +60,7 @@
 	"Refresh": "重新整理",
 	"Contacts": "聯絡方式",
 	"Report an issue": "回報問題",
-	"Meet us on Gitter": "透過 Gitter 聯絡我們",
+	"Meet us on %s": "透過 %s 聯絡我們",
 	"Send us email": "寄信給我們",
 	"Documents": "文件",
 	"Features": "功能簡介",

--- a/public/views/shared/help-modal.ejs
+++ b/public/views/shared/help-modal.ejs
@@ -17,7 +17,9 @@
                             <div class="panel-body">
                                 <a href="https://github.com/hackmdio/hackmd/issues" target="_blank"><i class="fa fa-tag fa-fw"></i> <%= __('Report an issue') %></a>
                                 <br>
-                                <a href="https://gitter.im/hackmdio/hackmd" target="_blank"><i class="fa fa-comments fa-fw"></i> <%= __('Meet us on Gitter') %></a>
+                                <a href="https://riot.im/app/#/room/#hackmd:matrix.org" target="_blank"><i class="fa fa-hashtag fa-fw"></i> <%= __('Meet us on %s', 'Matrix') %></a>
+                                <br>
+                                <a href="https://gitter.im/hackmdio/hackmd" target="_blank"><i class="fa fa-comments fa-fw"></i> <%= __('Meet us on %s', 'Gitter') %></a>
                             </div>
                         </div>
                         <div class="panel panel-default">


### PR DESCRIPTION
As an active part of the community prefers Matrix.org over Gitter, we
should link Matrix.org as a place to meet us.

As the matrix and gitter channels are interconnected. We don't loose any
message if a person decides to go for one or another.

We use an more universal way of translation to make it easier to provide
a link to various platforms.