### PR TITLE
Add check for noteId length

### DIFF
--- a/lib/models/note.js
+++ b/lib/models/note.js
@@ -211,6 +211,15 @@ module.exports = function (sequelize, DataTypes) {
           },
           // parse note id by LZString is deprecated, here for compability
           parseNoteIdByLZString: function (_callback) {
+            // Calculate minimal string length for an UUID that is encoded
+            // base64 encoded and optimize comparsion by using -1
+            // this should make a lot of LZ-String parsing errors obsolete
+            // as we can assume that a nodeId that is 48 chars or longer is a
+            // noteID.
+            const base64UuidLength = ((4 * 36) / 3) - 1
+            if (!(noteId.length > base64UuidLength)) {
+              return _callback(null, null)
+            }
             // try to parse note id by LZString Base64
             try {
               var id = LZString.decompressFromBase64(noteId)


### PR DESCRIPTION
As we know the length of an UUID we can check if the base64 string 
of the provided UUID is long enough for a legacy base64 encoded
nodeId and stop processing it in legacy mode, if it's not the case.

This should make the ugly warning way less common.

/cc @dekonnection