### PR TITLE
Move letter-avatars into own request

### DIFF
--- a/lib/letter-avatars.js
+++ b/lib/letter-avatars.js
@@ -1,16 +1,17 @@
 'use strict'
 // external modules
-var randomcolor = require('randomcolor')
+const randomcolor = require('randomcolor')
+const config = require('./config')
 
 // core
-module.exports = function (name) {
-  var color = randomcolor({
+exports.generateAvatar = function (name) {
+  const color = randomcolor({
     seed: name,
     luminosity: 'dark'
   })
-  var letter = name.substring(0, 1).toUpperCase()
+  const letter = name.substring(0, 1).toUpperCase()
 
-  var svg = '<?xml version="1.0" encoding="UTF-8" standalone="no"?>'
+  let svg = '<?xml version="1.0" encoding="UTF-8" standalone="no"?>'
   svg += '<svg xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" height="96" width="96" version="1.1" viewBox="0 0 96 96">'
   svg += '<g>'
   svg += '<rect width="96" height="96" fill="' + color + '" />'
@@ -20,5 +21,9 @@ module.exports = function (name) {
   svg += '</g>'
   svg += '</svg>'
 
-  return 'data:image/svg+xml;base64,' + new Buffer(svg).toString('base64')
+  return svg
+}
+
+exports.generateAvatarURL = function (name) {
+  return config.serverURL + '/user/' + name + '/avatar.svg'
 }

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -6,7 +6,7 @@ var scrypt = require('scrypt')
 
 // core
 var logger = require('../logger')
-var letterAvatars = require('../letter-avatars')
+var {generateAvatarURL} = require('../letter-avatars')
 
 module.exports = function (sequelize, DataTypes) {
   var User = sequelize.define('User', {
@@ -108,7 +108,7 @@ module.exports = function (sequelize, DataTypes) {
               if (bigger) photo = photo.replace(/(\?s=)\d*$/i, '$1400')
               else photo = photo.replace(/(\?s=)\d*$/i, '$196')
             } else {
-              photo = letterAvatars(profile.username)
+              photo = generateAvatarURL(profile.username)
             }
             break
           case 'mattermost':
@@ -117,7 +117,7 @@ module.exports = function (sequelize, DataTypes) {
               if (bigger) photo = photo.replace(/(\?s=)\d*$/i, '$1400')
               else photo = photo.replace(/(\?s=)\d*$/i, '$196')
             } else {
-              photo = letterAvatars(profile.username)
+              photo = generateAvatarURL(profile.username)
             }
             break
           case 'dropbox':
@@ -140,7 +140,7 @@ module.exports = function (sequelize, DataTypes) {
               if (bigger) photo += '?s=400'
               else photo += '?s=96'
             } else {
-              photo = letterAvatars(profile.username)
+              photo = generateAvatarURL(profile.username)
             }
             break
           case 'saml':
@@ -149,7 +149,7 @@ module.exports = function (sequelize, DataTypes) {
               if (bigger) photo += '?s=400'
               else photo += '?s=96'
             } else {
-              photo = letterAvatars(profile.username)
+              photo = generateAvatarURL(profile.username)
             }
             break
         }

--- a/lib/web/userRouter.js
+++ b/lib/web/userRouter.js
@@ -5,6 +5,7 @@ const Router = require('express').Router
 const response = require('../response')
 const models = require('../models')
 const logger = require('../logger')
+const {generateAvatar} = require('../letter-avatars')
 
 const UserRouter = module.exports = Router()
 
@@ -33,4 +34,10 @@ UserRouter.get('/me', function (req, res) {
       status: 'forbidden'
     })
   }
+})
+
+UserRouter.get('/user/:username/avatar.svg', function (req, res, next) {
+  res.setHeader('Content-Type', 'image/svg+xml')
+  res.setHeader('Cache-Control', 'public, max-age=86400')
+  res.send(generateAvatar(req.params.username))
 })


### PR DESCRIPTION
To prevent further weakening of our CSP policies, moving the Avatars
into a non-inline version is the way to go.

This implementation probably needs some beautification. But already fixes
the bug.

Fixes #802 