### PR TITLE
Fix possible file limit errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ Thanks for using! :smile:
 - Database (PostgreSQL, MySQL, MariaDB, SQLite, MSSQL) use charset `utf8`
 - npm (and its dependencies, especially [uWebSockets](https://github.com/uWebSockets/uWebSockets#nodejs-developers), [node-gyp](https://github.com/nodejs/node-gyp#installation))
 - For **building** HackMD we recommend to use a machine with at least **2GB** RAM
-- (optional) *For development you may need to increase the number of allowed open file descriptors on your machine*
 
 ### Instructions
 
@@ -329,5 +328,5 @@ See more at [http://operational-transformation.github.io/](http://operational-tr
 [standardjs-url]: https://github.com/feross/standard
 [codetriage-image]: https://www.codetriage.com/hackmdio/hackmd/badges/users.svg
 [codetriage-url]: https://www.codetriage.com/hackmdio/hackmd
-[poeditor-image]: https://img.shields.io/badge/POEditor-translate-green.svg
+[poeditor-image]: https://img.shields.io/badge/POEditor-translate-blue.svg
 [poeditor-url]: https://poeditor.com/join/project/1OpGjF2Jir

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "font-awesome": "^4.7.0",
     "formidable": "^1.0.17",
     "gist-embed": "~2.6.0",
+    "graceful-fs": "^4.1.11",
     "handlebars": "^4.0.6",
     "helmet": "^3.3.0",
     "highlight.js": "~9.9.0",

--- a/webpackBaseConfig.js
+++ b/webpackBaseConfig.js
@@ -4,6 +4,11 @@ var ExtractTextPlugin = require('extract-text-webpack-plugin')
 var HtmlWebpackPlugin = require('html-webpack-plugin')
 var CopyWebpackPlugin = require('copy-webpack-plugin')
 
+// Fix possible nofile-issues
+var fs = require('fs')
+var gracefulFs = require('graceful-fs')
+gracefulFs.gracefulify(fs)
+
 module.exports = {
   plugins: [
     new webpack.ProvidePlugin({


### PR DESCRIPTION
As we currently may need higher nofile limits than usual/default on
various systems this commit should probide a fix for that an allow to
build HackMD without highering these limits and increase security.

Inspiration was found in a [copy-webpack-plugin-issue][1] and found by
@thegcat. Thanks for that!

[1]:
https://github.com/webpack-contrib/copy-webpack-plugin/issues/59#issuecomment-228563990