### PR TITLE
Upgrade base64url package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "Idle.Js": "git+https://github.com/shawnmclean/Idle.js",
     "async": "^2.1.4",
     "aws-sdk": "^2.7.20",
-    "base64url": "^2.0.0",
+    "base64url": "^3.0.0",
     "blueimp-md5": "^2.6.0",
     "body-parser": "^1.15.2",
     "bootstrap": "^3.3.7",


### PR DESCRIPTION
There was recently a possible security problem with base64url. Shouldn't
really hit us but it doesn't hurt.

Details: https://snyk.io/vuln/npm:base64url:20180511