### PR TITLE
Fix callback validation

### DIFF
--- a/lib/web/imageRouter/filesystem.js
+++ b/lib/web/imageRouter/filesystem.js
@@ -2,6 +2,7 @@
 const url = require('url')
 
 const config = require('../../config')
+const logger = require('../../logger')
 
 exports.uploadImage = function (imagePath, callback) {
   if (!imagePath || typeof imagePath !== 'string') {
@@ -10,7 +11,7 @@ exports.uploadImage = function (imagePath, callback) {
   }
 
   if (!callback || typeof callback !== 'function') {
-    callback(new Error('Callback has to be a function'), null)
+    logger.error('Callback has to be a function')
     return
   }
 

--- a/lib/web/imageRouter/imgur.js
+++ b/lib/web/imageRouter/imgur.js
@@ -11,7 +11,7 @@ exports.uploadImage = function (imagePath, callback) {
   }
 
   if (!callback || typeof callback !== 'function') {
-    callback(new Error('Callback has to be a function'), null)
+    logger.error('Callback has to be a function')
     return
   }
 

--- a/lib/web/imageRouter/minio.js
+++ b/lib/web/imageRouter/minio.js
@@ -4,6 +4,7 @@ const path = require('path')
 
 const config = require('../../config')
 const {getImageMimeType} = require('../../utils')
+const logger = require('../../logger')
 
 const Minio = require('minio')
 const minioClient = new Minio.Client({
@@ -21,7 +22,7 @@ exports.uploadImage = function (imagePath, callback) {
   }
 
   if (!callback || typeof callback !== 'function') {
-    callback(new Error('Callback has to be a function'), null)
+    logger.error('Callback has to be a function')
     return
   }
 

--- a/lib/web/imageRouter/s3.js
+++ b/lib/web/imageRouter/s3.js
@@ -4,6 +4,7 @@ const path = require('path')
 
 const config = require('../../config')
 const {getImageMimeType} = require('../../utils')
+const logger = require('../../logger')
 
 const AWS = require('aws-sdk')
 const awsConfig = new AWS.Config(config.s3)
@@ -16,7 +17,7 @@ exports.uploadImage = function (imagePath, callback) {
   }
 
   if (!callback || typeof callback !== 'function') {
-    callback(new Error('Callback has to be a function'), null)
+    logger.error('Callback has to be a function')
     return
   }
 


### PR DESCRIPTION
Don't call the callback when it's undefined or not a function but log the error.