### PR TITLE
Fix i18n writing locale files in production

### DIFF
--- a/app.js
+++ b/app.js
@@ -131,7 +131,8 @@ if (config.csp.enable) {
 i18n.configure({
   locales: ['en', 'zh', 'zh-CN', 'zh-TW', 'fr', 'de', 'ja', 'es', 'ca', 'el', 'pt', 'it', 'tr', 'ru', 'nl', 'hr', 'pl', 'uk', 'hi', 'sv', 'eo', 'da'],
   cookie: 'locale',
-  directory: path.join(__dirname, '/locales')
+  directory: path.join(__dirname, '/locales'),
+  updateFiles: config.updateI18nFiles
 })
 
 app.use(cookieParser())

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -102,6 +102,9 @@ config.isSAMLEnable = config.saml.idpSsoUrl
 config.isOAuth2Enable = config.oauth2.clientID && config.oauth2.clientSecret
 config.isPDFExportEnable = config.allowPDFExport
 
+// Only update i18n files in development setups
+config.updateI18nFiles = (env === Environment.development)
+
 // merge legacy values
 let keys = Object.keys(config)
 const uppercase = /[A-Z]/


### PR DESCRIPTION
This commit should prevent the i18n module from adding missing
translations to the local files in setups that are not for development.
This way we keep the directory clean and idempotent.

Fixes #835