### PR TITLE
turn concatenated string into a multi-line template string

### DIFF
--- a/public/js/cover.js
+++ b/public/js/cover.js
@@ -34,25 +34,25 @@ import S from 'string'
 
 const options = {
   valueNames: ['id', 'text', 'timestamp', 'fromNow', 'time', 'tags', 'pinned'],
-  item: '<li class="col-xs-12 col-sm-6 col-md-6 col-lg-4">' +
-            '<span class="id" style="display:none;"></span>' +
-            '<a href="#">' +
-                '<div class="item">' +
-                    '<div class="ui-history-pin fa fa-thumb-tack fa-fw"></div>' +
-                    '<div class="ui-history-close fa fa-close fa-fw" data-toggle="modal" data-target=".delete-history-modal"></div>' +
-                    '<div class="content">' +
-                        '<h4 class="text"></h4>' +
-                        '<p>' +
-                            '<i><i class="fa fa-clock-o"></i> visited </i><i class="fromNow"></i>' +
-                            '<br>' +
-                            '<i class="timestamp" style="display:none;"></i>' +
-                            '<i class="time"></i>' +
-                        '</p>' +
-                        '<p class="tags"></p>' +
-                    '</div>' +
-                '</div>' +
-            '</a>' +
-           '</li>',
+  item: `<li class='col-xs-12 col-sm-6 col-md-6 col-lg-4'>
+          <span class='id' style='display:none;'></span>
+          <a href='#'>
+            <div class='item'>
+              <div class='ui-history-pin fa fa-thumb-tack fa-fw'></div>
+              <div class='ui-history-close fa fa-close fa-fw' data-toggle='modal' data-target='.delete-history-modal'></div>
+              <div class='content'>
+                <h4 class='text'></h4>
+                <p>
+                  <i><i class='fa fa-clock-o'></i> visited </i><i class='fromNow'></i>
+                  <br>
+                  <i class='timestamp' style='display:none;'></i>
+                  <i class='time'></i>
+                </p>
+                <p class='tags'></p>
+              </div>
+            </div>
+          </a>
+        </li>`,
   page: 18,
   pagination: [{
     outerWindow: 1


### PR DESCRIPTION
👋 

I like hackmd a lot and was looking to be helpful with development!
I noticed that the JS seemed to follow ES6 conventions such as `import` and arrow functions. So for a start, I thought I would change this turn this block of code into its ES6 alternative (from concat string into multi-line string with backtics).  I'm looking into other ways to contribute as well, and this was a quick start for me, no hard feelings if this PR doesn't get merged xD