### PR TITLE
Remove unused zh.json from repo

### DIFF
--- a/app.js
+++ b/app.js
@@ -129,7 +129,7 @@ if (config.csp.enable) {
 }
 
 i18n.configure({
-  locales: ['en', 'zh', 'zh-CN', 'zh-TW', 'fr', 'de', 'ja', 'es', 'ca', 'el', 'pt', 'it', 'tr', 'ru', 'nl', 'hr', 'pl', 'uk', 'hi', 'sv', 'eo', 'da', 'ko'],
+  locales: ['en', 'zh-CN', 'zh-TW', 'fr', 'de', 'ja', 'es', 'ca', 'el', 'pt', 'it', 'tr', 'ru', 'nl', 'hr', 'pl', 'uk', 'hi', 'sv', 'eo', 'da', 'ko'],
   cookie: 'locale',
   directory: path.join(__dirname, '/locales'),
   updateFiles: config.updateI18nFiles

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -1,1 +1,0 @@
-locales/zh-TW.json


### PR DESCRIPTION
Since the original idea of using a symlink didn't work anyway, we should
remove the zh.json symlink from the repo.  It doesn't provide any
benefit but alters the repo on start of HackMD.
