### PR TITLE
Fix possible error if HackMD is started with wrong workdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ There are some config settings you need to change in the files below.
 | `errorPath` | `./public/views/error.ejs` | error template file path |
 | `prettyPath` | `./public/views/pretty.ejs` | pretty template file path |
 | `slidePath` | `./public/views/slide.hbs` | slide template file path |
+| `uploadsPath` | `./public/uploads` | uploads directory - needs to be persistent when you use imageUploadType `filesystem` |
 | `sessionName` | `connect.sid` | cookie session name |
 | `sessionSecret` | `secret` | cookie session secret |
 | `sessionLife` | `14 * 24 * 60 * 60 * 1000` | cookie session life |

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -45,6 +45,7 @@ module.exports = {
   errorPath: './public/views/error.ejs',
   prettyPath: './public/views/pretty.ejs',
   slidePath: './public/views/slide.ejs',
+  uploadsPath: './public/uploads',
   // session
   sessionName: 'connect.sid',
   sessionSecret: 'secret',

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -173,6 +173,7 @@ config.hackmdPath = path.join(appRootPath, config.hackmdPath)
 config.errorPath = path.join(appRootPath, config.errorPath)
 config.prettyPath = path.join(appRootPath, config.prettyPath)
 config.slidePath = path.join(appRootPath, config.slidePath)
+config.uploadsPath = path.join(appRootPath, config.uploadsPath)
 
 // make config readonly
 config = deepFreeze(config)

--- a/lib/web/imageRouter/index.js
+++ b/lib/web/imageRouter/index.js
@@ -16,7 +16,7 @@ imageRouter.post('/uploadimage', function (req, res) {
   form.keepExtensions = true
 
   if (config.imageUploadType === 'filesystem') {
-    form.uploadDir = 'public/uploads'
+    form.uploadDir = config.uploadsPath
   }
 
   form.parse(req, function (err, fields, files) {


### PR DESCRIPTION
In https://github.com/hackmdio/hackmd/issues/834 is described how
starting HackMD crashes when using the wrong working dir.

This is caused by a relative path in our upload routine. This change
should fix it and prevent future crashes.

Fixes #834