### PR TITLE
Allow to disable gravatar

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ There are some config settings you need to change in the files below.
 | `HMD_EMAIL` | `true` or `false` | set to allow email signin |
 | `HMD_ALLOW_PDF_EXPORT` | `true` or `false` | Enable or disable PDF exports |
 | `HMD_ALLOW_EMAIL_REGISTER` | `true` or `false` | set to allow email register (only applied when email is set, default is `true`. Note `bin/manage_users` might help you if registration is `false`.) |
+| `HMD_ALLOW_GRAVATAR` | `true` or `false` | set to `false` to disable gravatar as profile picture source on your instance |
 | `HMD_IMAGE_UPLOAD_TYPE` | `imgur`, `s3`, `minio` or `filesystem` | Where to upload images. For S3, see our Image Upload Guides for [S3](docs/guides/s3-image-upload.md) or [Minio](docs/guides/minio-image-upload.md) |
 | `HMD_S3_ACCESS_KEY_ID` | no example | AWS access key id |
 | `HMD_S3_SECRET_ACCESS_KEY` | no example | AWS secret key |
@@ -271,6 +272,7 @@ There are some config settings you need to change in the files below.
 | `documentMaxLength` | `100000` | note max length |
 | `email` | `true` or `false` | set to allow email signin |
 | `allowEmailRegister`  | `true` or `false` | set to allow email register (only applied when email is set, default is `true`. Note `bin/manage_users` might help you if registration is `false`.) |
+| `allowGravatar` | `true` or `false` | set to `false` to disable gravatar as profile picture source on your instance |
 | `imageUploadType` | `imgur`, `s3`, `minio`, `azure` or `filesystem`(default) | Where to upload images. For S3, see our Image Upload Guides for [S3](docs/guides/s3-image-upload.md) or [Minio](docs/guides/minio-image-upload.md)|
 | `minio` | `{ "accessKey": "YOUR_MINIO_ACCESS_KEY", "secretKey": "YOUR_MINIO_SECRET_KEY", "endpoint": "YOUR_MINIO_HOST", port: 9000, secure: true }` | When `imageUploadType` is set to `minio`, you need to set this key. Also checkout our [Minio Image Upload Guide](docs/guides/minio-image-upload.md) |
 | `s3` | `{ "accessKeyId": "YOUR_S3_ACCESS_KEY_ID", "secretAccessKey": "YOUR_S3_ACCESS_KEY", "region": "YOUR_S3_REGION" }` | When `imageuploadtype` be set to `s3`, you would also need to setup this key, check our [S3 Image Upload Guide](docs/guides/s3-image-upload.md) |

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -146,5 +146,6 @@ module.exports = {
   },
   email: true,
   allowEmailRegister: true,
+  allowGravatar: true,
   allowPDFExport: true
 }

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -120,5 +120,6 @@ module.exports = {
   },
   email: toBooleanConfig(process.env.HMD_EMAIL),
   allowEmailRegister: toBooleanConfig(process.env.HMD_ALLOW_EMAIL_REGISTER),
+  allowGravatar: toBooleanConfig(process.env.HMD_ALLOW_GRAVATAR),
   allowPDFExport: toBooleanConfig(process.env.HMD_ALLOW_PDF_EXPORT)
 }

--- a/lib/letter-avatars.js
+++ b/lib/letter-avatars.js
@@ -1,5 +1,6 @@
 'use strict'
 // external modules
+const md5 = require('blueimp-md5')
 const randomcolor = require('randomcolor')
 const config = require('./config')
 
@@ -24,6 +25,17 @@ exports.generateAvatar = function (name) {
   return svg
 }
 
-exports.generateAvatarURL = function (name) {
-  return config.serverURL + '/user/' + name + '/avatar.svg'
+exports.generateAvatarURL = function (name, email = '', big = true) {
+  let photo
+  if (email !== '' && config.allowGravatar) {
+    photo = 'https://www.gravatar.com/avatar/' + md5(email.toLowerCase())
+    if (big) {
+      photo += '?s=400'
+    } else {
+      photo += '?s=96'
+    }
+  } else {
+    photo = config.serverURL + '/user/' + (name || email.substring(0, email.lastIndexOf('@')) || md5(email.toLowerCase())) + '/avatar.svg'
+  }
+  return photo
 }

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -1,6 +1,5 @@
 'use strict'
 // external modules
-var md5 = require('blueimp-md5')
 var Sequelize = require('sequelize')
 var scrypt = require('scrypt')
 
@@ -128,10 +127,7 @@ module.exports = function (sequelize, DataTypes) {
             }
             break
           case 'dropbox':
-            // no image api provided, use gravatar
-            photo = 'https://www.gravatar.com/avatar/' + md5(profile.emails[0].value)
-            if (bigger) photo += '?s=400'
-            else photo += '?s=96'
+            photo = generateAvatarURL('', profile.emails[0].value, bigger)
             break
           case 'google':
             photo = profile.photos[0].value
@@ -139,35 +135,19 @@ module.exports = function (sequelize, DataTypes) {
             else photo = photo.replace(/(\?sz=)\d*$/i, '$196')
             break
           case 'ldap':
-            // no image api provided,
-            // use gravatar if email exists,
-            // otherwise generate a letter avatar
-            if (profile.emails[0]) {
-              photo = 'https://www.gravatar.com/avatar/' + md5(profile.emails[0])
-              if (bigger) photo += '?s=400'
-              else photo += '?s=96'
-            } else {
-              photo = generateAvatarURL(profile.username)
-            }
+            photo = generateAvatarURL(profile.username, profile.emails[0], bigger)
             break
           case 'saml':
-            if (profile.emails[0]) {
-              photo = 'https://www.gravatar.com/avatar/' + md5(profile.emails[0])
-              if (bigger) photo += '?s=400'
-              else photo += '?s=96'
-            } else {
-              photo = generateAvatarURL(profile.username)
-            }
+            photo = generateAvatarURL(profile.username, profile.emails[0], bigger)
             break
         }
         return photo
       },
       parseProfileByEmail: function (email) {
-        var photoUrl = 'https://www.gravatar.com/avatar/' + md5(email)
         return {
           name: email.substring(0, email.lastIndexOf('@')),
-          photo: photoUrl + '?s=96',
-          biggerphoto: photoUrl + '?s=400'
+          photo: generateAvatarURL('', email, false),
+          biggerphoto: generateAvatarURL('', email, true)
         }
       }
     }


### PR DESCRIPTION
Since Gravatar is an external image source and not perfect from a
privacy perspective, forbidding it allows to improve privacy.

This commit also simplifies and optimizes the avatar code.

Fixes #840 