### PR TITLE
Move config out of statics path

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,22 +26,6 @@ var response = require('./lib/response')
 var models = require('./lib/models')
 var csp = require('./lib/csp')
 
-// generate front-end constants by template
-var constpath = path.join(__dirname, './public/js/lib/common/constant.ejs')
-var data = {
-  domain: config.domain,
-  urlpath: config.urlPath,
-  debug: config.debug,
-  version: config.version,
-  DROPBOX_APP_KEY: config.dropbox.appKey,
-  allowedUploadMimeTypes: config.allowedUploadMimeTypes
-}
-
-ejs.renderFile(constpath, data, {}, function (err, str) {
-  if (err) throw new Error(err)
-  fs.writeFileSync(path.join(__dirname, './public/build/constant.js'), str)
-})
-
 // server setup
 var app = express()
 var server = null

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -45,6 +45,7 @@ module.exports = {
   errorPath: './public/views/error.ejs',
   prettyPath: './public/views/pretty.ejs',
   slidePath: './public/views/slide.ejs',
+  constantsPath: './public/js/lib/common/constant.ejs',
   uploadsPath: './public/uploads',
   // session
   sessionName: 'connect.sid',

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -173,6 +173,7 @@ config.hackmdPath = path.join(appRootPath, config.hackmdPath)
 config.errorPath = path.join(appRootPath, config.errorPath)
 config.prettyPath = path.join(appRootPath, config.prettyPath)
 config.slidePath = path.join(appRootPath, config.slidePath)
+config.constantsPath = path.join(appRootPath, config.constantsPath)
 config.uploadsPath = path.join(appRootPath, config.uploadsPath)
 
 // make config readonly

--- a/lib/web/statusRouter.js
+++ b/lib/web/statusRouter.js
@@ -90,3 +90,20 @@ statusRouter.post('/temp', urlencodedParser, function (req, res) {
     }
   }
 })
+
+statusRouter.get('/config', function (req, res) {
+  var data = {
+    domain: config.domain,
+    urlpath: config.urlPath,
+    debug: config.debug,
+    version: config.version,
+    DROPBOX_APP_KEY: config.dropbox.appKey,
+    allowedUploadMimeTypes: config.allowedUploadMimeTypes
+  }
+  res.set({
+    'Cache-Control': 'private', // only cache by client
+    'X-Robots-Tag': 'noindex, nofollow', // prevent crawling
+    'HackMD-Version': config.version
+  })
+  res.render(config.constantsPath, data)
+})

--- a/public/views/includes/scripts.ejs
+++ b/public/views/includes/scripts.ejs
@@ -1,4 +1,4 @@
-<script src="<%= webpackConfig.output.baseUrl %>/build/constant.js"></script>
+<script src="<%= webpackConfig.output.baseUrl %>/config"></script>
 <% for (var chunk in htmlWebpackPlugin.files.chunks) { %>
 <script src="<%= webpackConfig.output.baseUrl %><%= htmlWebpackPlugin.files.chunks[chunk].entry %>" defer></script>
 <% } %>


### PR DESCRIPTION
Since static path is providing with a high expiration data, we provide
configs via API. This shouldn't add any noticeable load while making it
uncached and this way working again.

Fixes #847 