### PR TITLE
Fix possible line-ending issues for init note

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -145,6 +145,8 @@ function responseHackMD (res, note) {
 
 function newNote (req, res, next) {
   var owner = null
+  var body = req.body ? req.body : ''
+  body = body.replace(/[\r]/g, '')
   if (req.isAuthenticated()) {
     owner = req.user.id
   } else if (!config.allowAnonymous) {
@@ -153,7 +155,7 @@ function newNote (req, res, next) {
   models.Note.create({
     ownerId: owner,
     alias: req.alias ? req.alias : null,
-    content: req.body ? req.body : ''
+    content: body
   }).then(function (note) {
     return res.redirect(config.serverURL + '/' + models.Note.encodeNoteId(note.id))
   }).catch(function (err) {


### PR DESCRIPTION
By uploading a malicous note currently it is possible to prevent this
note from being edited. This happens when using Windows line endings.

With this commit we remove all `\r` characters from the notes and this
way prevent this problem.

Fixes #822 