### PR TITLE
Fix broken images in PDF caused by misconfigred server URL

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -327,15 +327,18 @@ function actionInfo (req, res, note) {
 }
 
 function actionPDF (req, res, note) {
+  var url = config.serverURL || 'http://' + req.get('host')
   var body = note.content
   var extracted = models.Note.extractMeta(body)
+  var content = extracted.markdown
   var title = models.Note.decodeTitle(note.title)
 
   if (!fs.existsSync(config.tmpPath)) {
     fs.mkdirSync(config.tmpPath)
   }
   var path = config.tmpPath + '/' + Date.now() + '.pdf'
-  markdownpdf().from.string(extracted.markdown).to(path, function () {
+  content = content.replace(/\]\(\//g, '](' + url + '/')
+  markdownpdf().from.string(content).to(path, function () {
     var stream = fs.createReadStream(path)
     var filename = title
     // Be careful of special characters


### PR DESCRIPTION
As it turns out, if the serverURL can't be generated correctly, HackMD
will use relative paths in image upload. This causes broken links in
PDF.

With this commit we force absolute links during PDF creation which
hopefully fixes the problem.

Fixes #820