### PR TITLE
Fix breaking regex

### DIFF
--- a/lib/web/imageRouter/filesystem.js
+++ b/lib/web/imageRouter/filesystem.js
@@ -15,5 +15,5 @@ exports.uploadImage = function (imagePath, callback) {
     return
   }
 
-  callback(null, url.resolve(config.serverURL + '/', imagePath.match(/^public\/(.+$)/)[1]))
+  callback(null, url.resolve(config.serverURL + '/', imagePath.match(/public\/(.+)$/)[1]))
 }


### PR DESCRIPTION
The image upload regex breaks with the new path for uploads.

This commit fixes it.